### PR TITLE
Repool Bug - HemePact/Impact

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/PoolInfoApi.java
+++ b/src/main/java/org/mskcc/limsrest/service/PoolInfoApi.java
@@ -24,7 +24,7 @@ public class PoolInfoApi {
     private final static Log log = LogFactory.getLog(SetQcStatus.class);
     private final ConnectionPoolLIMS conn;
 
-    public PoolInfoApi(ConnectionPoolLIMS conn){
+    public PoolInfoApi(ConnectionPoolLIMS conn) {
         this.conn = conn;
     }
 
@@ -33,7 +33,7 @@ public class PoolInfoApi {
      * the LIMS tree hierarchy from the input record to find the right sample
      *
      * @param recordId, SeqAnalysisSampleQC record Id
-     * @param status - Status to set pooled sample to
+     * @param status    - Status to set pooled sample to
      * @return ResponseEntity<String>
      */
     @RequestMapping("/setPooledSampleStatus")
@@ -49,7 +49,7 @@ public class PoolInfoApi {
             try {
                 Boolean success = (Boolean) result.get();
                 String response;
-                if(success){
+                if (success) {
                     response = String.format("Set status for record %s to '%s'", recordId, mappedStatus);
                 } else {
                     response = String.format("Failed to set status for record %s to '%s'", recordId, mappedStatus);

--- a/src/main/java/org/mskcc/limsrest/service/SetPooledSampleStatus.java
+++ b/src/main/java/org/mskcc/limsrest/service/SetPooledSampleStatus.java
@@ -15,8 +15,8 @@ import static org.mskcc.util.VeloxConstants.SEQ_ANALYSIS_SAMPLE_QC;
 public class SetPooledSampleStatus extends LimsTask {
     private static Log log = LogFactory.getLog(ToggleSampleQcStatus.class);
 
-    long recordId;
-    String status;
+    private long recordId;
+    private String status;
 
     private QcStatusAwareProcessAssigner qcStatusAwareProcessAssigner = new QcStatusAwareProcessAssigner();
 

--- a/src/main/java/org/mskcc/limsrest/service/ToggleSampleQcStatus.java
+++ b/src/main/java/org/mskcc/limsrest/service/ToggleSampleQcStatus.java
@@ -79,7 +79,6 @@ public class ToggleSampleQcStatus extends LimsTask {
                 dataRecordManager.storeAndCommit("SeqAnalysisSampleQC updated to " + status, user);
                 log.info("SeqAnalysisSampleQC updated to:" + status + " from:" + currentStatusLIMS);
             } else {
-                // TODO - WHY IS THIS HERE? It doesn't modify the QCStatus page
                 List<DataRecord> request = dataRecordManager.queryDataRecords("Request", "RequestId = '" + requestId + "'", user);
                 if (request.size() != 1) {
                     return "Invalid Request Id";


### PR DESCRIPTION
For HemePact & Impact, repool should repool the post-qc pooled library and not the Pre-pool Library. For all other recipes, WES, it makes sense to repool farther upstream. Due to nature of Impact/HemePact, change is to change sample status after QC.

JIRA: http://plvpipetrack1.mskcc.org:8090/projects/SAP/issues/SAP-504?filter=myopenissues