### PR TITLE
New delivery and access fields

### DIFF
--- a/src/main/java/org/mskcc/limsrest/controller/GetRecentDeliveries.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetRecentDeliveries.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Future;
 
 /**
  * Used by the QC site so they can view recently delivered projects in the QC meetings.
+ * Also used by EmailDelivery code (https://github.com/mskcc/fastq-plus).
  */
 @RestController
 @RequestMapping("/")

--- a/src/main/java/org/mskcc/limsrest/service/GetDelivered.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetDelivered.java
@@ -121,6 +121,10 @@ public class GetDelivered extends LimsTask {
                 } catch (Exception e) {
                 }
                 try {
+                    rs.setAnalysisType((String) requestFields.get("AnalysisType"));
+                } catch (Exception e) {
+                }
+                try {
                     rs.setRequestType((String) requestFields.get("RequestName"));
                 } catch (Exception e) {
                 }

--- a/src/main/java/org/mskcc/limsrest/service/GetRequestSamplesTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestSamplesTask.java
@@ -66,7 +66,7 @@ public class GetRequestSamplesTask {
                 boolean igoComplete = samplesIGOComplete.contains(othersampleId);
                 // same othersampleId as other samples but these failed, could check exemplarSampleStatus too
                 // remove if qc status lookup done by IGO ID
-                if ("07078_E_1".equals(igoId) || "07078_E_2".equals(igoId) || "07078_E_5".equals(igoId) )
+                if ("07078_E_1".equals(igoId) || "07078_E_2".equals(igoId) || "07078_E_5".equals(igoId))
                     igoComplete = false;
 
                 RequestSample rs = new RequestSample(othersampleId, igoId, igoComplete);
@@ -92,6 +92,8 @@ public class GetRequestSamplesTask {
             rsl.setDataAnalystName(requestDataRecord.getStringVal("DataAnalyst", user));
             rsl.setDataAnalystEmail(requestDataRecord.getStringVal("DataAnalystEmail", user));
             rsl.setOtherContactEmails(requestDataRecord.getStringVal("MailTo", user));
+            rsl.setQcAccessEmails(requestDataRecord.getStringVal("QcAccessEmails", user));
+            rsl.setDataAccessEmails(requestDataRecord.getStringVal("DataAccessEmails", user));
 
             return rsl;
         } catch (Throwable e) {
@@ -181,6 +183,8 @@ public class GetRequestSamplesTask {
         public String investigatorName, investigatorEmail;
         public String dataAnalystName, dataAnalystEmail;
         public String otherContactEmails;
+        public String dataAccessEmails;
+        public String qcAccessEmails;
         public String strand; // only for RNA
 
         public List<RequestSample> samples;
@@ -286,6 +290,14 @@ public class GetRequestSamplesTask {
         public void setOtherContactEmails(String otherContactEmails) {
             this.otherContactEmails = otherContactEmails;
         }
+
+        public String getQcAccessEmails() { return qcAccessEmails; }
+
+        public void setQcAccessEmails(String qcAccessEmails) { this.qcAccessEmails = qcAccessEmails; }
+
+        public String getDataAccessEmails() { return dataAccessEmails; }
+
+        public void setDataAccessEmails(String dataAccessEmails) { this.dataAccessEmails = dataAccessEmails; }
     }
 
     public static class RequestSample {

--- a/src/main/java/org/mskcc/limsrest/service/GetSampleQc.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSampleQc.java
@@ -335,6 +335,7 @@ public class GetSampleQc {
             runAndCatchNpe(() -> rs.setInvestigatorEmail((String) requestFields.get("Investigatoremail")));
             runAndCatchNpe(() -> rs.setAutorunnable((Boolean) requestFields.get("BicAutorunnable")));
             runAndCatchNpe(() -> rs.setAnalysisRequested((Boolean) requestFields.get("BICAnalysis")));
+            runAndCatchNpe(() -> rs.setAnalysisType((String) requestFields.get("AnalysisType")));
             runAndCatchNpe(() -> rs.setCmoProject((String) requestFields.get("CMOProjectID")));
             runAndCatchNpe(() -> rs.setProjectManager((String) requestFields.get("ProjectManager")));
         } catch (Throwable e) {

--- a/src/main/java/org/mskcc/limsrest/service/LimsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/LimsTask.java
@@ -96,6 +96,8 @@ public abstract class LimsTask implements VeloxExecutable<Object>, Callable<Obje
             runAndCatchNpe(() -> requestDetailed.setRequestId((String) requestFields.get("RequestId")));
             runAndCatchNpe(() -> requestDetailed.setFaxNumber((String) requestFields.get("FaxNum")));
             runAndCatchNpe(() -> requestDetailed.setMailTo((String) requestFields.get("MailTo")));
+            runAndCatchNpe(() -> requestDetailed.setDataAccessEmails((String) requestFields.get("DataAccessEmails")));
+            runAndCatchNpe(() -> requestDetailed.setQcAccessEmails((String) requestFields.get("QcAccessEmails")));
             runAndCatchNpe(() -> requestDetailed.setInvestigator((String) requestFields.get("Investigator")));
             runAndCatchNpe(() -> requestDetailed.setIrbWaiverComments((String) requestFields.get
                     ("IRBandWaiverComments")));
@@ -138,6 +140,7 @@ public abstract class LimsTask implements VeloxExecutable<Object>, Callable<Obje
             runAndCatchNpe(() -> requestDetailed.setAutorunnable((Boolean) requestFields.get("BicAutorunnable")));
             runAndCatchNpe(() -> requestDetailed.setFastqRequested((Boolean) requestFields.get("FASTQ")));
             runAndCatchNpe(() -> requestDetailed.setAnalysisRequested((Boolean) requestFields.get("BICAnalysis")));
+            runAndCatchNpe(() -> requestDetailed.setAnalysisType((String) requestFields.get("AnalysisType")));
             runAndCatchNpe(() -> requestDetailed.setHighPriority((Boolean) requestFields.get("HighPriority")));
         } catch (Throwable e) {
             requestDetailed.setInvestigator("Annotation failed: " + e.getMessage());

--- a/src/main/java/org/mskcc/limsrest/service/RequestDetailed.java
+++ b/src/main/java/org/mskcc/limsrest/service/RequestDetailed.java
@@ -15,6 +15,7 @@ public class RequestDetailed {
    private String fundNumber;
    private String contactName;
    private String dataAnalyst;
+   //   to be replaced by dataAccessEmails
    private String dataAnalystEmail;
    private String dataDeliveryType;
    private String cmoProjectId;
@@ -26,7 +27,10 @@ public class RequestDetailed {
    private String furthest;  
    private String investigator;
    private String irbWaiverComments;
+   //   to be replaced by dataAccessEmails and qcAccessEmails
    private String mailTo;
+   private String dataAccessEmails;
+   private String qcAccessEmails;
    private String pi;
    private String projectNotes;
    private String group;
@@ -48,6 +52,7 @@ public class RequestDetailed {
    private String servicesRequested;
    private String studyId;
    private String communicationNotes;
+   private String analysisType;
 
 
 
@@ -135,6 +140,21 @@ public class RequestDetailed {
       if(mailTo.split("@").length == mailTo.split(",").length + 1){
            this.mailTo = mailTo;
       }
+   }
+   public void setQcAccessEmails(String qcAccessEmails){
+      //if this isn't well formed, don't set
+      if(qcAccessEmails.split("@").length == qcAccessEmails.split(",").length + 1){
+           this.qcAccessEmails = qcAccessEmails;
+      }
+   }
+   public void setDataAccessEmails(String dataAccessEmails){
+      //if this isn't well formed, don't set
+      if(dataAccessEmails.split("@").length == dataAccessEmails.split(",").length + 1){
+           this.dataAccessEmails = dataAccessEmails;
+      }
+   }
+   public void setAnalysisType(String analysisType){
+	this.analysisType = analysisType;
    }
    public void setPi(String pi){
 	this.pi = pi;
@@ -301,8 +321,10 @@ public class RequestDetailed {
    public String getDataDeliveryType(){
 	return dataDeliveryType;
    }
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-  public String getCmoContactName(){
+   @JsonInclude(JsonInclude.Include.NON_EMPTY)
+   public String getAnalysisType(){ return analysisType; }
+   @JsonInclude(JsonInclude.Include.NON_EMPTY)
+   public String getCmoContactName(){
      return cmoContactName;
   }
 
@@ -336,6 +358,10 @@ public class RequestDetailed {
    public String getMailTo(){
      return mailTo;
    }
+   @JsonInclude(JsonInclude.Include.NON_EMPTY)
+   public String getDataAccessEmails(){ return dataAccessEmails; }
+   @JsonInclude(JsonInclude.Include.NON_EMPTY)
+   public String getQcAccessEmails(){ return qcAccessEmails; }
    @JsonInclude(JsonInclude.Include.NON_EMPTY)
    public String getPi(){
 	return pi;

--- a/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
+++ b/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
@@ -18,6 +18,7 @@ public class RequestSummary {
     private String investigatorEmail;
     private String piEmail;
     private String projectManager;
+    private String analysisType;
     private boolean pipelinable;
     private boolean analysisRequested;
     private long recordId;
@@ -60,6 +61,8 @@ public class RequestSummary {
     public void setAnalysisRequested(boolean req) {
         this.analysisRequested = req;
     }
+
+    public void setAnalysisType(String s) { this.analysisType = s;  }
 
     public void setRecordId(long id) {
         this.recordId = id;
@@ -110,6 +113,9 @@ public class RequestSummary {
     public boolean getAnalysisRequested() {
         return analysisRequested;
     }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getAnalysisType() { return analysisType; }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public long getRecordId() {


### PR DESCRIPTION
Do not merge before email delivery crontab code is ready, I might add more changes.

These changes add the following fields to LIMSrest results:
- AnalysisType, containing a String comprised of the AnalysisType picklist in the LIMS (FASTQ ONLY, CCS, BIC, IGO)
=> to eventually replace LIMS BicAnalysisRequested and FastQ checkboxes
- DataAccessEmails
- QcAccessEmails 
=> to eventually replace LIMS MailTo and AnalystEmail fields

If the fields are not available or empty in the LIMS, the result will either attach them empty or discard them, depending on the existing functionality in the class.

Changes to the following:
Endpoints:
controller/GetRecentDeliveries.java

Tasks/Services:
service/GetDelivered.java
service/RequestSummary.java 
service/RequestDetailed.java
service/GetRequestSamplesTask.java
service/GetSampleQc.java
service/LimsTask.java

Changes to these services should not negatively impact other endpoints since they only *add* more fields. 
Here is a list of endpoints that will return extended results because of my changes:
GetRequestSamples
RequestDetailed
GetSampleQC
GetHiSeq
GetDelivered
GetUndelivered
RunSummary

Do you know of any other teams that might have been working with outputs? If we actually want to get rid of the deprecated MailTo, BicAnalysisRequested, and FastQOnly columns in request, they will need to be notified.
For example, if "newPipelineRun" is still used to create Jira tickets for Roslin, we should inform CAS. 