### PR TITLE
Adding local target to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,12 @@ if (target== 'dev'){
         from "src/test-site-res/resources"
         into "src/main/resources"
     }
+} else if(target == 'local'){
+    copy {
+        from "src/local/resources"
+        into "src/main/resources"
+    }
+    version += 'l'
 } else {
     copy {
         from "src/production/resources"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ nexusUrlReleases=http://bale:8081/service/local/repositories/releases/content
 nexusUrlSnapshots=http://bale:8081/service/local/repositories/snapshots/content
 nexusUsername=admin
 nexusPassword=
-target=dev
+target=local

--- a/src/local/resources/app.properties
+++ b/src/local/resources/app.properties
@@ -1,0 +1,1 @@
+# TODO - Get app.properties

--- a/src/local/resources/connect.txt
+++ b/src/local/resources/connect.txt
@@ -1,0 +1,8 @@
+lims.host=
+lims.port=
+lims.guid=
+
+lims.user1=
+lims.pword1=
+lims.user2=
+lims.pword2=

--- a/src/local/resources/limsrestcredentials.properties
+++ b/src/local/resources/limsrestcredentials.properties
@@ -1,0 +1,1 @@
+# TODO - Get limsrestcredentials.properties


### PR DESCRIPTION
Forces specification of "dev" or "local" in the `gradle.properties` target field. `dev` is for tango & `local` is for local credentials (e.g. "apistreidd")

```
$ find . -type f -name "*.war"
./build/libs/LimsRest##-1.17.3d.war
./build/libs/LimsRest##-1.17.3.war
./build/libs/LimsRest##-1.17.3l.war
```