### PR TITLE
Endpoint: "/getUndeliveredProjects"

### DIFF
--- a/src/main/java/org/mskcc/limsrest/controller/GetUndeliveredProjects.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetUndeliveredProjects.java
@@ -1,11 +1,8 @@
 package org.mskcc.limsrest.controller;
 
-import com.velox.api.datarecord.IoError;
-import com.velox.api.datarecord.NotFound;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mskcc.limsrest.ConnectionLIMS;
-import org.mskcc.limsrest.service.GetRequestTrackingTask;
 import org.mskcc.limsrest.service.GetUndeliveredProjectsTask;
 import org.mskcc.limsrest.service.RequestSummary;
 import org.springframework.http.HttpStatus;
@@ -15,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 import static org.mskcc.limsrest.util.Utils.getResponseEntity;
@@ -31,8 +27,7 @@ public class GetUndeliveredProjects {
     }
 
     @GetMapping("/getUndeliveredProjects")
-    public ResponseEntity<List<RequestSummary>> getContent(@RequestParam(value = "time") String time,
-                                                          HttpServletRequest request) {
+    public ResponseEntity<List<RequestSummary>> getContent(@RequestParam(value = "time", required = false) String time) {
 
         log.info(String.format("/getUndeliveredProjects for projects in past %s days", time));
 
@@ -40,7 +35,7 @@ public class GetUndeliveredProjects {
         Integer numDays = 7;
         try {
             numDays = Integer.parseInt(time);
-        } catch(NumberFormatException e){
+        } catch (NumberFormatException e) {
             log.warn(String.format("Failed to parse time: %s. Using default 7 days", time));
         }
         GetUndeliveredProjectsTask t = new GetUndeliveredProjectsTask(numDays);

--- a/src/main/java/org/mskcc/limsrest/controller/GetUndeliveredProjects.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetUndeliveredProjects.java
@@ -1,0 +1,50 @@
+package org.mskcc.limsrest.controller;
+
+import com.velox.api.datarecord.IoError;
+import com.velox.api.datarecord.NotFound;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mskcc.limsrest.ConnectionLIMS;
+import org.mskcc.limsrest.service.GetRequestTrackingTask;
+import org.mskcc.limsrest.service.GetUndeliveredProjectsTask;
+import org.mskcc.limsrest.service.RequestSummary;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+import static org.mskcc.limsrest.util.Utils.getResponseEntity;
+
+@RestController
+@RequestMapping("/")
+public class GetUndeliveredProjects {
+    private final static Log log = LogFactory.getLog(GetUndeliveredProjects.class);
+    private final ConnectionLIMS conn;
+
+    public GetUndeliveredProjects(ConnectionLIMS conn) {
+        this.conn = conn;
+    }
+
+    @GetMapping("/getUndeliveredProjects")
+    public ResponseEntity<List<RequestSummary>> getContent(@RequestParam(value = "time") String time,
+                                                          HttpServletRequest request) {
+
+        log.info(String.format("/getUndeliveredProjects for projects in past %s days", time));
+
+        // Standardize input
+        Integer numDays = 7;
+        try {
+            numDays = Integer.parseInt(time);
+        } catch(NumberFormatException e){
+            log.warn(String.format("Failed to parse time: %s. Using default 7 days", time));
+        }
+        GetUndeliveredProjectsTask t = new GetUndeliveredProjectsTask(numDays);
+        List<RequestSummary> requestTracker = t.execute(this.conn.getConnection());
+        return getResponseEntity(requestTracker, HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/mskcc/limsrest/service/GetDelivered.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetDelivered.java
@@ -133,7 +133,7 @@ public class GetDelivered extends LimsTask {
                 } catch (Exception e) {
                 }
                 try {
-                    rs.setSampleNumber(((Short) requestFields.get("SampleNumber")).intValue());
+                    rs.setSampleNumber(((Short) requestFields.get("SampleNumber")));
                 } catch (Exception e) {
                     log.info(e.getMessage());
                 }

--- a/src/main/java/org/mskcc/limsrest/service/GetSampleQc.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSampleQc.java
@@ -63,7 +63,7 @@ public class GetSampleQc {
                 RequestSummary rs = new RequestSummary(project);
                 HashSet<String> runSet = new HashSet<>();
                 annotateRequestSummary(rs, r, user); // fill in all data at request level except sample number
-                rs.setSampleNumber((new Short(r.getShortVal("SampleNumber", user))).intValue());
+                rs.setSampleNumber((new Short(r.getShortVal("SampleNumber", user))));
 
                 List<DataRecord> qcRecords;
                 qcRecords = dataRecordManager.queryDataRecords("SeqAnalysisSampleQC", "Request = '" + project + "'", user);

--- a/src/main/java/org/mskcc/limsrest/service/GetUndelivered.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetUndelivered.java
@@ -101,7 +101,7 @@ public class GetUndelivered extends LimsTask {
                 } catch (Exception e) {
                 }
                 try {
-                    rs.setSampleNumber(((Short) requestFields.get("SampleNumber")).intValue());
+                    rs.setSampleNumber(((Short) requestFields.get("SampleNumber")));
                 } catch (Exception e) {
                     log.info(e.getMessage());
                 }

--- a/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
@@ -1,0 +1,115 @@
+package org.mskcc.limsrest.service;
+
+import com.velox.api.datarecord.*;
+import com.velox.api.user.User;
+import com.velox.api.util.IoUtil;
+import com.velox.sapioutils.client.standalone.VeloxConnection;
+import com.velox.sloan.cmo.recmodels.RequestModel;
+import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mskcc.limsrest.util.Utils;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+import java.util.*;
+
+/**
+ * A queued task that finds all requests that have all qc in a status of Failed or Passed but haven't been delivered
+ * or that are being redelivered within a window
+ * @author David Streid (Aaron Gabow)
+ */
+public class GetUndeliveredProjectsTask extends LimsTask {
+    private static Log log = LogFactory.getLog(GetUndeliveredProjectsTask.class);
+    private Integer daysToExamine;
+
+    public GetUndeliveredProjectsTask(Integer daysToExamine){
+        this.daysToExamine = daysToExamine;
+    }
+
+    @PreAuthorize("hasRole('READ')")
+    @Override
+    public List<RequestSummary> execute(VeloxConnection conn) {
+        // Set<DataRecord> undeliveredSet = new HashSet<>();
+        User user = conn.getUser();
+
+        List<DataRecord> undeliveredRecords = new ArrayList<>();
+        String query = String.format("%s IS NULL OR %s >  UNIX_TIMESTAMP(NOW() - INTERVAL %d DAY) * 1000",
+            RequestModel.RECENT_DELIVERY_DATE, RequestModel.RECENT_DELIVERY_DATE, this.daysToExamine);
+        try {
+            undeliveredRecords = conn.getDataRecordManager().queryDataRecords(RequestModel.DATA_TYPE_NAME, query, user);
+        } catch (NotFound | RemoteException | IoError e){
+            log.error("Failed to retrieve Projects from Database");
+        }
+
+        /*
+        AuditLog auditLog = null;
+        try {
+            auditLog = user.getAuditLog();
+        } catch(RemoteException e){
+            log.error("Failed to get auditLog");
+        }
+        boolean reviewComplete, hasQc, requiresDelivery;
+        long deliveryDate;
+        log.info(String.format("Retrieving data on %d projects", undeliveredList.size()));
+        for (DataRecord undeliveredProject : undeliveredList) {
+            reviewComplete = true;
+            hasQc = false;                  // Only oneSeqAnalysisSampleQCModel descendant is required to "have QC"
+            requiresDelivery = false;
+
+            deliveryDate = Utils.getRecordLongValue(undeliveredProject, RequestModel.RECENT_DELIVERY_DATE, user);
+            String requestId = Utils.getRecordStringValue(undeliveredProject, RequestModel.REQUEST_ID, user);
+            List<DataRecord> qcs = Utils.getDescendentsOfDataRecord(undeliveredProject, SeqAnalysisSampleQCModel.DATA_TYPE_NAME, user);
+            for (DataRecord qc : qcs) {
+                String seqQcDescendant = Utils.getRecordStringValue(qc, "RequestId", user);
+                hasQc = hasQc || requestId.equals(seqQcDescendant);
+                String seqQcStatusPickListVal = Utils.getRecordPickListVal(qc,SeqAnalysisSampleQCModel.SEQ_QCSTATUS, user);
+                if (!SEQ_QC_STATUS_PASSED.equals(seqQcStatusPickListVal) &&
+                    !SEQ_QC_STATUS_FAILED.equals(seqQcStatusPickListVal)) {
+                    reviewComplete = false;
+                } else {
+                    List<AuditLogEntry> qcHistory = new ArrayList<>();
+                    if(auditLog != null) {
+                        try {
+                            qcHistory = auditLog.getAuditLogHistory(qc, false, user);
+                        } catch (IoError | RemoteException e) {
+                            log.error(String.format("Failed to get audit log on Qc Record: %d", qc.getRecordId()));
+                        }
+                        if (qcHistory.size() > 0 && qcHistory.get(0).timestamp > deliveryDate) {
+                            requiresDelivery = true;
+                        }
+                    }
+                }
+            }
+            if (reviewComplete && hasQc && requiresDelivery) {
+                undeliveredSet.add(undeliveredProject);
+            }
+        }
+         */
+
+        // Transform requests into a redacted API response
+        List<RequestSummary> undeliveredRequests = new LinkedList<>();
+        for (DataRecord request : undeliveredRecords) {
+            Map<String, Object> requestFields = new HashMap<>();
+            try {
+                 requestFields = request.getFields(user);
+            } catch (RemoteException e) {
+                log.error(e.getMessage(), e);
+            }
+            String requestId = (String) requestFields.get(RequestModel.REQUEST_ID);
+            RequestSummary rs = new RequestSummary(requestId);
+            rs.setInvestigator((String) requestFields.computeIfAbsent(RequestModel.INVESTIGATOR, k -> ""));
+            rs.setPi((String) requestFields.computeIfAbsent(RequestModel.LABORATORY_HEAD, k -> ""));
+            rs.setAnalysisRequested((Boolean) requestFields.computeIfAbsent(RequestModel.BICANALYSIS, k -> Boolean.FALSE));
+            rs.setRequestType((String) requestFields.computeIfAbsent(RequestModel.REQUEST_NAME, k -> ""));
+            rs.setProjectManager((String) requestFields.computeIfAbsent(RequestModel.PROJECT_MANAGER, k -> ""));
+            rs.setSampleNumber(((Short) requestFields.computeIfAbsent(RequestModel.SAMPLE_NUMBER, k->0)).intValue());
+            undeliveredRequests.add(rs);
+        }
+
+        return undeliveredRequests;
+    }
+}

--- a/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
@@ -2,20 +2,16 @@ package org.mskcc.limsrest.service;
 
 import com.velox.api.datarecord.*;
 import com.velox.api.user.User;
-import com.velox.api.util.IoUtil;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
 import com.velox.sloan.cmo.recmodels.RequestModel;
-import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.mskcc.limsrest.util.Utils;
 import org.springframework.security.access.prepost.PreAuthorize;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.util.*;
+
+import static org.mskcc.limsrest.util.Utils.*;
 
 /**
  * A queued task that finds all requests that have all qc in a status of Failed or Passed but haven't been delivered
@@ -49,69 +45,20 @@ public class GetUndeliveredProjectsTask extends LimsTask {
             log.error(String.format("No undelivered projects for the past %d days", this.daysToExamine));
             return new ArrayList<>();
         }
-
-        /*
-        AuditLog auditLog = null;
-        try {
-            auditLog = user.getAuditLog();
-        } catch(RemoteException e){
-            log.error("Failed to get auditLog");
-        }
-        boolean reviewComplete, hasQc, requiresDelivery;
-        long deliveryDate;
-        log.info(String.format("Retrieving data on %d projects", undeliveredList.size()));
-        for (DataRecord undeliveredProject : undeliveredList) {
-            reviewComplete = true;
-            hasQc = false;                  // Only oneSeqAnalysisSampleQCModel descendant is required to "have QC"
-            requiresDelivery = false;
-
-            deliveryDate = Utils.getRecordLongValue(undeliveredProject, RequestModel.RECENT_DELIVERY_DATE, user);
-            String requestId = Utils.getRecordStringValue(undeliveredProject, RequestModel.REQUEST_ID, user);
-            List<DataRecord> qcs = Utils.getDescendentsOfDataRecord(undeliveredProject, SeqAnalysisSampleQCModel.DATA_TYPE_NAME, user);
-            for (DataRecord qc : qcs) {
-                String seqQcDescendant = Utils.getRecordStringValue(qc, "RequestId", user);
-                hasQc = hasQc || requestId.equals(seqQcDescendant);
-                String seqQcStatusPickListVal = Utils.getRecordPickListVal(qc,SeqAnalysisSampleQCModel.SEQ_QCSTATUS, user);
-                if (!SEQ_QC_STATUS_PASSED.equals(seqQcStatusPickListVal) &&
-                    !SEQ_QC_STATUS_FAILED.equals(seqQcStatusPickListVal)) {
-                    reviewComplete = false;
-                } else {
-                    List<AuditLogEntry> qcHistory = new ArrayList<>();
-                    if(auditLog != null) {
-                        try {
-                            qcHistory = auditLog.getAuditLogHistory(qc, false, user);
-                        } catch (IoError | RemoteException e) {
-                            log.error(String.format("Failed to get audit log on Qc Record: %d", qc.getRecordId()));
-                        }
-                        if (qcHistory.size() > 0 && qcHistory.get(0).timestamp > deliveryDate) {
-                            requiresDelivery = true;
-                        }
-                    }
-                }
-            }
-            if (reviewComplete && hasQc && requiresDelivery) {
-                undeliveredSet.add(undeliveredProject);
-            }
-        }
-         */
-
+        
         // Transform requests into a redacted API response
         List<RequestSummary> undeliveredRequests = new LinkedList<>();
         for (DataRecord request : undeliveredRecords) {
-            Map<String, Object> requestFields = new HashMap<>();
-            try {
-                 requestFields = request.getFields(user);
-            } catch (RemoteException e) {
-                log.error(e.getMessage(), e);
-            }
-            String requestId = (String) requestFields.get(RequestModel.REQUEST_ID);
+            String requestId = getRecordStringValue(request, RequestModel.REQUEST_ID, user);
             RequestSummary rs = new RequestSummary(requestId);
-            rs.setInvestigator((String) requestFields.computeIfAbsent(RequestModel.INVESTIGATOR, k -> ""));
-            rs.setPi((String) requestFields.computeIfAbsent(RequestModel.LABORATORY_HEAD, k -> ""));
-            rs.setAnalysisRequested((Boolean) requestFields.computeIfAbsent(RequestModel.BICANALYSIS, k -> Boolean.FALSE));
-            rs.setRequestType((String) requestFields.computeIfAbsent(RequestModel.REQUEST_NAME, k -> ""));
-            rs.setProjectManager((String) requestFields.computeIfAbsent(RequestModel.PROJECT_MANAGER, k -> ""));
-            rs.setSampleNumber(((Short) requestFields.computeIfAbsent(RequestModel.SAMPLE_NUMBER, k->0)).intValue());
+
+            rs.setInvestigator(getRecordStringValue(request, RequestModel.INVESTIGATOR, user));
+            rs.setPi(getRecordStringValue(request, RequestModel.LABORATORY_HEAD, user));
+            rs.setAnalysisRequested(getRecordBooleanValue(request, RequestModel.BICANALYSIS, user));
+            rs.setRequestType(getRecordStringValue(request, RequestModel.REQUEST_NAME, user));
+            rs.setProjectManager(getRecordStringValue(request, RequestModel.PROJECT_MANAGER, user));
+            rs.setSampleNumber(getRecordShortValue(request,RequestModel.SAMPLE_NUMBER, user));
+
             undeliveredRequests.add(rs);
         }
 

--- a/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
@@ -45,6 +45,11 @@ public class GetUndeliveredProjectsTask extends LimsTask {
             log.error("Failed to retrieve Projects from Database");
         }
 
+        if(undeliveredRecords.size() == 0){
+            log.error(String.format("No undelivered projects for the past %d days", this.daysToExamine));
+            return new ArrayList<>();
+        }
+
         /*
         AuditLog auditLog = null;
         try {

--- a/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
+++ b/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
@@ -22,7 +22,7 @@ public class RequestSummary {
     private boolean pipelinable;
     private boolean analysisRequested;
     private long recordId;
-    private Integer sampleNumber;
+    private Short sampleNumber;
     private String restStatus;
     private String specialDelivery;
 
@@ -100,7 +100,7 @@ public class RequestSummary {
         investigatorEmail = email;
     }
 
-    public void setSampleNumber(Integer sampleNumber) {
+    public void setSampleNumber(Short sampleNumber) {
         this.sampleNumber = sampleNumber;
     }
 
@@ -162,7 +162,7 @@ public class RequestSummary {
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public Integer getSampleNumber() {
+    public Short getSampleNumber() {
         return sampleNumber;
     }
 

--- a/src/main/java/org/mskcc/limsrest/util/Utils.java
+++ b/src/main/java/org/mskcc/limsrest/util/Utils.java
@@ -146,6 +146,24 @@ public class Utils {
     }
 
     /**
+     * Safely retrieves a Short Value from a dataRecord
+     *
+     * @param record
+     * @param key
+     * @param user
+     * @return
+     */
+    public static Short getRecordShortValue(DataRecord record, String key, User user) {
+        try {
+            return record.getShortVal(key, user);
+        } catch (NotFound | RemoteException | NullPointerException e) {
+            LOGGER.error(String.format("Failed to get (Short) key %s from Sample Record: %d", key, record.getRecordId()));
+        }
+        return null;
+    }
+
+
+    /**
      * Safely retrieves a Boolean Value from a dataRecord
      *
      * @param record


### PR DESCRIPTION
Description: Returning list of undelivered projects for the past n days.
Also, modified RequestSummary's SampleNumber field to a Short (from Integer) because everywhere it is set, it is converted from a short to an integer (See GetSampleQC & GetDelivered)

Sample Response
```
[
   {
      "samples": [],
      "requestId": "05427_I",
      "requestType": "ddPCR",
      "investigator": "Parisa Momtaz",
      "pi": "Paul Chapman",
      "analysisRequested": false,
      "recordId": 0,
      "sampleNumber": 68,
      "restStatus": "SUCCESS",
      "autorunnable": false,
      "deliveryDate": []
   },
   ...
]
```