### PR TITLE
Fixing FailedSample Count Determination

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -54,7 +54,7 @@ public class GetRequestTrackingTask {
         DataRecordManager drm = vConn.getDataRecordManager();
 
         String serviceId = getBankedSampleServiceId(this.requestId, user, drm);
-        Request request = new Request(requestId, serviceId);
+        Request request = new Request(this.requestId, serviceId);
 
         if (serviceId != null && !serviceId.equals("")) {
             // Add "submitted" stage if a serviceID exists
@@ -298,7 +298,7 @@ public class GetRequestTrackingTask {
     }
 
     /**
-     * Calculates the stage the overall sample is at based on the least advanced path and merging across all samples.
+     * Calculates the stage the overall project is at by aggregating the stages of each projectSample in the project.
      * On merge event, update the following -
      *      start/update times
      *      Total
@@ -322,19 +322,18 @@ public class GetRequestTrackingTask {
                 projectStage = stageMap.get(stageName);
                 projectStage.updateStageTimes(sampleStage);
                 projectStage.addStartingSample(SAMPLE_COUNT);
-                isFailedStage = sampleStage.getFailedSamplesCount() > 0;
-                if (sampleStage.getComplete() && !isFailedStage) {
-                    // Only non-failed, completed stages are considered to have "ended" the stage
-                    projectStage.addEndingSample(SAMPLE_COUNT);
-                }
-                // Incremement the number of failed samples in the aggregated
-                if (isFailedStage) {
-                    projectStage.addFailedSample();
-                }
             } else {
-                Integer endingCount = sampleStage.getComplete() ? SAMPLE_COUNT : 0;
-                projectStage = new SampleStageTracker(stageName, SAMPLE_COUNT, endingCount, sampleStage.getStartTime(), sampleStage.getUpdateTime());
+                projectStage = new SampleStageTracker(stageName, SAMPLE_COUNT, 0, sampleStage.getStartTime(), sampleStage.getUpdateTime());
                 stageMap.put(stageName, projectStage);
+            }
+            isFailedStage = sampleStage.getFailedSamplesCount() > 0;
+            if (sampleStage.getComplete() && !isFailedStage) {
+                // Only non-failed, completed stages are considered to have "ended" the stage
+                projectStage.addEndingSample(SAMPLE_COUNT);
+            }
+            // Incremement the number of failed samples in the aggregated
+            if (isFailedStage) {
+                projectStage.addFailedSample();
             }
         }
 

--- a/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
@@ -33,6 +33,7 @@ public class GetUndeliveredProjectsTask extends LimsTask {
         User user = conn.getUser();
 
         List<DataRecord> undeliveredRecords = new ArrayList<>();
+        // Unix timestamp is to the millisecond, which is why we multiply by 1000
         String query = String.format("%s IS NULL OR %s >  UNIX_TIMESTAMP(NOW() - INTERVAL %d DAY) * 1000",
             RequestModel.RECENT_DELIVERY_DATE, RequestModel.RECENT_DELIVERY_DATE, this.daysToExamine);
         try {

--- a/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
@@ -125,7 +125,7 @@ public class GetRequestTrackingTaskTest {
                         .build(),
                 new ProjectBuilder("06302_AG")
                         .addStage(STAGE_LIBRARY_PREP, true, 382, 382, 0)
-                        .addStage(STAGE_PENDING_USER_DECISION, true, 2, 1, 1)
+                        .addStage(STAGE_PENDING_USER_DECISION, true, 2, 0, 2)
                         // TODO - Failed should be 48 & completed 332, but sequencing failures are difficult
                         .addStage(STAGE_SEQUENCING, false, 380, 332, 0)
                         .addStage(STAGE_DATA_QC, false, 380, 332, 48)


### PR DESCRIPTION
ISSUE: First time a stage is encountered, it was not considering whether or not that stage was failed
FIX: Moved logic for incrementing failed sample count to outside the if/else for retrieving/creating the sample stage