### PR TITLE
Returning sample ID instead of data record name (more user friendly)

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/WorkflowSample.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/WorkflowSample.java
@@ -44,7 +44,7 @@ public class WorkflowSample extends StatusTracker {
         this.user = conn.getConnection().getUser();
         this.children = new ArrayList<>();
         this.recordId = record.getRecordId();
-        this.recordName = getRecordStringValue(record, SampleModel.DATA_RECORD_NAME, this.user);
+        this.recordName = getRecordStringValue(record, SampleModel.SAMPLE_ID, this.user);
         this.record = record;
         this.parent = null;
 


### PR DESCRIPTION
* SampleID is the "IGO ID" in the LIMS user interface, which is what most LIMS users will be used to
E.g. Returning "02756_B_1" versus "529748"