### PR TITLE
Removing Delivered Projects from "/getUndeliveredProjects"

### DIFF
--- a/src/main/java/org/mskcc/limsrest/controller/GetUndeliveredProjects.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetUndeliveredProjects.java
@@ -27,18 +27,10 @@ public class GetUndeliveredProjects {
     }
 
     @GetMapping("/getUndeliveredProjects")
-    public ResponseEntity<List<RequestSummary>> getContent(@RequestParam(value = "time", required = false) String time) {
+    public ResponseEntity<List<RequestSummary>> getContent() {
+        log.info("/getUndeliveredProjects for projects not delivered");
 
-        log.info(String.format("/getUndeliveredProjects for projects in past %s days", time));
-
-        // Standardize input
-        Integer numDays = 7;
-        try {
-            numDays = Integer.parseInt(time);
-        } catch (NumberFormatException e) {
-            log.warn(String.format("Failed to parse time: %s. Using default 7 days", time));
-        }
-        GetUndeliveredProjectsTask t = new GetUndeliveredProjectsTask(numDays);
+        GetUndeliveredProjectsTask t = new GetUndeliveredProjectsTask();
         List<RequestSummary> requestTracker = t.execute(this.conn.getConnection());
         return getResponseEntity(requestTracker, HttpStatus.OK);
     }

--- a/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetUndeliveredProjectsTask.java
@@ -20,22 +20,14 @@ import static org.mskcc.limsrest.util.Utils.*;
  */
 public class GetUndeliveredProjectsTask extends LimsTask {
     private static Log log = LogFactory.getLog(GetUndeliveredProjectsTask.class);
-    private Integer daysToExamine;
-
-    public GetUndeliveredProjectsTask(Integer daysToExamine){
-        this.daysToExamine = daysToExamine;
-    }
 
     @PreAuthorize("hasRole('READ')")
     @Override
     public List<RequestSummary> execute(VeloxConnection conn) {
-        // Set<DataRecord> undeliveredSet = new HashSet<>();
         User user = conn.getUser();
 
         List<DataRecord> undeliveredRecords = new ArrayList<>();
-        // Unix timestamp is to the millisecond, which is why we multiply by 1000
-        String query = String.format("%s IS NULL OR %s >  UNIX_TIMESTAMP(NOW() - INTERVAL %d DAY) * 1000",
-            RequestModel.RECENT_DELIVERY_DATE, RequestModel.RECENT_DELIVERY_DATE, this.daysToExamine);
+        String query = String.format("%s IS NULL", RequestModel.RECENT_DELIVERY_DATE);
         try {
             undeliveredRecords = conn.getDataRecordManager().queryDataRecords(RequestModel.DATA_TYPE_NAME, query, user);
         } catch (NotFound | RemoteException | IoError e){
@@ -43,7 +35,7 @@ public class GetUndeliveredProjectsTask extends LimsTask {
         }
 
         if(undeliveredRecords.size() == 0){
-            log.error(String.format("No undelivered projects for the past %d days", this.daysToExamine));
+            log.error(String.format("No undelivered projects found. Incredible!"));
             return new ArrayList<>();
         }
         


### PR DESCRIPTION
- Or condition will return delivered projects from the past week `UNIX_TIMESTAMP(NOW()` - INTERVAL 7 DAY) * 1000`
This should just be removed as this should only return non-delivered projects