### PR TITLE
Fix IMPACT 505 CMO ID generation, add rna seq run info and add tube ID to pipeline sample metadata endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ configurations {
 }
 
 dependencies {
-    compile 'org.mskcc.common:common-domain:2.13.0'
+    compile 'org.mskcc.common:common-domain:2.14'
 
     compile "io.springfox:springfox-swagger-ui:2.9.2"
     compile "io.springfox:springfox-swagger2:2.9.2"

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     compile ('javax.servlet:jstl:1.2')
 
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.9'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
 
     compile 'com.velox.internalproducts:veloxapi:10.6.1-b777'
     compile 'com.velox.sloan.cmo:sloancmo:2.21.1-LIMS10.6.1_b84'

--- a/src/main/java/org/mskcc/limsrest/service/ArchivedFastq.java
+++ b/src/main/java/org/mskcc/limsrest/service/ArchivedFastq.java
@@ -14,6 +14,26 @@ public class ArchivedFastq {
 
     public ArchivedFastq() {}
 
+    public String getRunId() {
+        return run.substring(0, run.lastIndexOf("_"));
+    }
+
+    /**
+     * Extract flowcell from run - JAX_0454_AHHWKVBBXY, TOMS_5394_000000000-J2FY2, JOHNSAWYERS_0239_000000000-G5TVF
+     * @return
+     */
+    public String getFlowCellId() {
+        if (run == null || run.length() < 10)
+            return "";
+
+        if (run.contains("_000000000")) {
+            return run.substring(run.length() - 5,run.length());
+        } else {
+            int lastUnderscore = run.lastIndexOf('_');
+            return run.substring(lastUnderscore + 2,run.length());
+        }
+    }
+
     @Override
     public String toString() {
         return "ArchivedFastq{" +

--- a/src/main/java/org/mskcc/limsrest/service/GetSampleManifestTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSampleManifestTask.java
@@ -111,7 +111,7 @@ public class GetSampleManifestTask {
         SampleManifest sampleManifest = getSampleLevelFields(igoId, samples, sample, dataRecordManager, user);
 
         sampleManifest.setTubeId(getTubeId(sample, user));
-        
+
         if (!isPipelineRecipe(recipe)) {
             return getFastqsAndCheckTheirQCStatus(igoId, user, sample, sampleManifest);
         }

--- a/src/main/java/org/mskcc/limsrest/service/GetSampleManifestTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSampleManifestTask.java
@@ -19,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import java.rmi.RemoteException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 /**
@@ -570,19 +571,17 @@ public class GetSampleManifestTask {
                         log.info("Ignoring failed fastq: " + f);
                 }
 
-                // for passed fastqs separate into each run and get flowcell information
+                // for remaining fastqs separate list into each run and get flowcell information and run date
                 HashMap<String, SampleManifest.Run> runMap = new HashMap<>();
                 for (ArchivedFastq fastq : passedFastqs) {
                     if (runMap.containsKey(fastq.run)) {  // if the run already exists just add the fastq path
                         SampleManifest.Run run = runMap.get(fastq.run);
                         run.fastqs.add(fastq.fastq);
                     } else {
-                        // TODO
-                        // TODO break up string like "JAX_0454_AHHWKVBBXY"
-                        // TODO
-                        String runId = "";
-                        String flowCellId = "";
-                        String runDate = fastq.fastqLastModified.toString(); // 2020-07-31
+                        String runId = fastq.getRunId();
+                        String flowCellId = fastq.getFlowCellId();
+                        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+                        String runDate = dateFormat.format(fastq.fastqLastModified); // 2020-07-31
                         SampleManifest.Run run = new SampleManifest.Run(runId, flowCellId, runDate);
                         run.fastqs = new ArrayList<>();
                         run.fastqs.add(fastq.fastq);

--- a/src/main/java/org/mskcc/limsrest/service/SampleManifest.java
+++ b/src/main/java/org/mskcc/limsrest/service/SampleManifest.java
@@ -31,6 +31,7 @@ public class SampleManifest {
     private String collectionYear;
     private String sex;
     private String species;
+    private String tubeId;
     private String cfDNA2dBarcode;
 
     private String baitSet;
@@ -171,6 +172,10 @@ public class SampleManifest {
 
     public SampleManifest() {}
 
+    public String getTubeId() { return tubeId; }
+
+    public void setTubeId(String tubeId) { this.tubeId = tubeId; }
+
     public String getCfDNA2dBarcode() { return cfDNA2dBarcode; }
 
     public void setCfDNA2dBarcode(String cfDNA2dBarcode) { this.cfDNA2dBarcode = cfDNA2dBarcode; }
@@ -293,18 +298,25 @@ public class SampleManifest {
     public String toString() {
         return "SampleManifest{" +
                 "igoId='" + igoId + '\'' +
+                ", cmoInfoIgoId='" + cmoInfoIgoId + '\'' +
                 ", cmoSampleName='" + cmoSampleName + '\'' +
+                ", sampleName='" + sampleName + '\'' +
+                ", cmoSampleClass='" + cmoSampleClass + '\'' +
                 ", cmoPatientId='" + cmoPatientId + '\'' +
                 ", investigatorSampleId='" + investigatorSampleId + '\'' +
                 ", oncoTreeCode='" + oncoTreeCode + '\'' +
                 ", tumorOrNormal='" + tumorOrNormal + '\'' +
                 ", tissueLocation='" + tissueLocation + '\'' +
+                ", specimenType='" + specimenType + '\'' +
                 ", sampleOrigin='" + sampleOrigin + '\'' +
                 ", preservation='" + preservation + '\'' +
                 ", collectionYear='" + collectionYear + '\'' +
                 ", sex='" + sex + '\'' +
                 ", species='" + species + '\'' +
+                ", tubeId='" + tubeId + '\'' +
+                ", cfDNA2dBarcode='" + cfDNA2dBarcode + '\'' +
                 ", baitSet='" + baitSet + '\'' +
+                ", qcReports=" + qcReports +
                 ", libraries=" + libraries +
                 '}';
     }

--- a/src/main/java/org/mskcc/limsrest/service/SampleManifest.java
+++ b/src/main/java/org/mskcc/limsrest/service/SampleManifest.java
@@ -132,6 +132,12 @@ public class SampleManifest {
         public List<Integer> flowCellLanes = new ArrayList<>();
         public List<String> fastqs;
 
+        public Run(String runId, String flowCellId, String runDate) {
+            this.runId = runId;
+            this.flowCellId = flowCellId;
+            this.runDate = runDate;
+        }
+
         public Run(String runMode, String runId, String flowCellId, String readLength, String runDate) {
             this.runMode = runMode;
             this.runId = runId;

--- a/src/main/java/org/mskcc/limsrest/service/promote/BankedSampleSaver.java
+++ b/src/main/java/org/mskcc/limsrest/service/promote/BankedSampleSaver.java
@@ -2,13 +2,14 @@ package org.mskcc.limsrest.service.promote;
 
 import com.velox.api.datarecord.*;
 import com.velox.api.user.User;
-import org.apache.log4j.Logger;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mskcc.domain.sample.BankedSample;
 
 import java.rmi.RemoteException;
 
 public class BankedSampleSaver implements RecordSaver {
-    private static final Logger LOGGER = Logger.getLogger(BankedSampleSaver.class);
+    private static final Log LOGGER = LogFactory.getLog(BankedSampleSaver.class);
 
     @Override
     public void save(BankedSample bankedSample, DataRecordManager dataRecordManager, User user) {

--- a/src/test/java/org/mskcc/limsrest/service/ArchivedFastqTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/ArchivedFastqTest.java
@@ -1,0 +1,31 @@
+package org.mskcc.limsrest.service;
+
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+public class ArchivedFastqTest {
+
+    @Test
+    public void getFlowCellIdTypeA() {
+        ArchivedFastq x = new ArchivedFastq();
+        x.setRun("JAX_0454_AHHWKVBBXY");
+        assertEquals("HHWKVBBXY", x.getFlowCellId());
+    }
+
+    @Test
+    public void getFlowCellIdTypeB() {
+        ArchivedFastq x = new ArchivedFastq();
+        x.setRun("TOMS_5394_000000000-J2FY2");
+        assertEquals("J2FY2", x.getFlowCellId());
+    }
+
+    @Test
+    public void getRunId() {
+        ArchivedFastq x = new ArchivedFastq();
+        x.setRun("TOMS_5394_000000000-J2FY2");
+        assertEquals("TOMS_5394", x.getRunId());
+    }
+}


### PR DESCRIPTION
- references new common-domain version 2.14 which adds Recipe.IMPACT505 to fix CMO sample ID generation for IMPACT 505
- adds Tube ID to pipeline sample metadata endpoint
- adds some run info like flowcell to pipeline metadata endpoint