### PR TITLE
getStages returns ordered stage map

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -133,16 +133,16 @@ public class GetRequestTrackingTask {
 
         Boolean isStagesComplete = true;
         Integer numFailed = 0;
-        Integer numComplete = 0;
         Integer numTotal = 0;
         SampleStageTracker stage;
+        Integer numComplete = 0;
         for (Map.Entry<String, SampleStageTracker> requestStage : stages.entrySet()) {
             stage = requestStage.getValue();
             isStagesComplete = isStagesComplete && stage.getComplete();
             numFailed += stage.getFailedSamplesCount();
             numTotal = stage.getSize() > numTotal ? stage.getSize() : numTotal;
+            // Reset numComplete as the # of ending samples in last stage (stages is ordered)
             numComplete = stage.getEndingSamples();
-
         }
         projectStatus.put("stagesComplete", isStagesComplete);
         projectStatus.put("completed", numComplete);

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/Request.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/Request.java
@@ -54,7 +54,12 @@ public class Request {
     }
 
     public Map<String, SampleStageTracker> getStages() {
-        return new HashMap<String, SampleStageTracker>(this.stages);
+        Map<String, SampleStageTracker> cloned = new TreeMap<>(new StageComp());
+        for(Map.Entry<String, SampleStageTracker> entry : this.stages.entrySet()){
+            cloned.put(entry.getKey(), entry.getValue());
+        }
+        return cloned;
+
     }
 
     public List<ProjectSample> getSamples() {


### PR DESCRIPTION
Fixes issue where the summary calculations were being done on an unordered list of stages for a request

Fix (Note - "Awaiting Processing" should be come first in the ordering of stages. This causes the summary tab to report a "completed" number of 1, from "Awaiting Processing", instead of the 81 it should from "Data QC")

**BEFORE**
```
{
   "request": {
   "summary": {
   "total": 105,
   "RecentDeliveryDate": 1594836487057,
   "stagesComplete": false,
   "isIgoComplete": true,
   "completed": 1,
   "failed": 0
},
"stages": [
...
{
   "stage": "Data QC",
   "completedSamples": 81,
   "totalSamples": 100,
   "startTime": 1582213973966,
   "updateTime": 1583871263655,
   "complete": false,
   "failedSamples": 0
},
{
   "stage": "Awaiting Processing",
   "completedSamples": 1,
   "totalSamples": 1,
   "startTime": 1581004517481,
   "updateTime": 1583354681173,
   "complete": true,
   "failedSamples": 0
}
],
```
**AFTER**
```
{
   "request": {
   "summary": {
   "total": 105,
   "RecentDeliveryDate": 1594836487057,
   "stagesComplete": false,
   "isIgoComplete": true,
   "completed": 81,
   "failed": 0
},
"stages": [
...

{
   "stage": "Awaiting Processing",
   "completedSamples": 1,
   "totalSamples": 1,
   "startTime": 1581004517481,
   "updateTime": 1583354681173,
   "complete": true,
   "failedSamples": 0
},
{
   "stage": "Data QC",
   "completedSamples": 81,
   "totalSamples": 100,
   "startTime": 1582213973966,
   "updateTime": 1583871263655,
   "complete": false,
   "failedSamples": 0
}
],
```