### PR TITLE
SampleStageTracker => StageTracker,

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -18,6 +18,7 @@ import java.rmi.RemoteException;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.mskcc.limsrest.service.requesttracker.StageTracker.SAMPLE_COUNT;
 import static org.mskcc.limsrest.util.StatusTrackerConfig.*;
 import static org.mskcc.limsrest.util.Utils.*;
 
@@ -28,7 +29,6 @@ import static org.mskcc.limsrest.util.Utils.*;
  */
 public class GetRequestTrackingTask {
     private static Log log = LogFactory.getLog(GetRequestTrackingTask.class);
-    private static final Integer SAMPLE_COUNT = 1; // Default size for a sample, i.e. single tracked sample has size: 1
 
     private static String[] requestDataLongFields = new String[]{RequestModel.RECEIVED_DATE};
     private static String[] requestDataStringFields = new String[]{

--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -28,7 +28,7 @@ import static org.mskcc.limsrest.util.Utils.*;
  */
 public class GetRequestTrackingTask {
     private static Log log = LogFactory.getLog(GetRequestTrackingTask.class);
-    private static Integer SAMPLE_COUNT = 1;
+    private static final Integer SAMPLE_COUNT = 1; // Default size for a sample, i.e. single tracked sample has size: 1
 
     private static String[] requestDataLongFields = new String[]{RequestModel.RECEIVED_DATE};
     private static String[] requestDataStringFields = new String[]{
@@ -65,7 +65,7 @@ public class GetRequestTrackingTask {
             // Add "submitted" stage if a serviceID exists
             // TODO - Why is this the case (QA: "06302_W")
             // TODO - Place in thread as this can be executed independently
-            SampleStageTracker submittedStage = getSubmittedStage(serviceId, user, drm);
+            StageTracker submittedStage = getSubmittedStage(serviceId, user, drm);
             request.addStage(STAGE_SUBMITTED, submittedStage);
         }
 
@@ -86,8 +86,8 @@ public class GetRequestTrackingTask {
 
         // Aggregate Project-Level stage information. Stages are added one-by-one as previous stages (E.g. "submitted")
         // may have been added and should not be overwritten
-        Map<String, SampleStageTracker> projectStages = getProjectStagesFromSamples(projectSamples);
-        for (Map.Entry<String, SampleStageTracker> requestStage : projectStages.entrySet()) {
+        Map<String, StageTracker> projectStages = getProjectStagesFromSamples(projectSamples);
+        for (Map.Entry<String, StageTracker> requestStage : projectStages.entrySet()) {
             request.addStage(requestStage.getKey(), requestStage.getValue());
         }
 
@@ -119,7 +119,7 @@ public class GetRequestTrackingTask {
      * @param user
      * @return
      */
-    private Map<String, Object> getProjectSummary(DataRecord requestRecord, Map<String, SampleStageTracker> stages, User user){
+    private Map<String, Object> getProjectSummary(DataRecord requestRecord, Map<String, StageTracker> stages, User user){
         Map<String, Object> projectStatus = new HashMap<>();
 
         // IGO Completion is confirmed by delivery, which sets the "RecentDeliveryDate" field
@@ -134,9 +134,9 @@ public class GetRequestTrackingTask {
         Boolean isStagesComplete = true;
         Integer numFailed = 0;
         Integer numTotal = 0;
-        SampleStageTracker stage;
+        StageTracker stage;
         Integer numComplete = 0;
-        for (Map.Entry<String, SampleStageTracker> requestStage : stages.entrySet()) {
+        for (Map.Entry<String, StageTracker> requestStage : stages.entrySet()) {
             stage = requestStage.getValue();
             isStagesComplete = isStagesComplete && stage.getComplete();
             numFailed += stage.getFailedSamplesCount();
@@ -294,11 +294,11 @@ public class GetRequestTrackingTask {
      * @param projectSamples - All samples of a request
      * @return
      */
-    public Map<String, SampleStageTracker> getProjectStagesFromSamples(List<ProjectSample> projectSamples) {
-        List<SampleStageTracker> sampleStages = projectSamples.stream()
+    public Map<String, StageTracker> getProjectStagesFromSamples(List<ProjectSample> projectSamples) {
+        List<StageTracker> sampleStages = projectSamples.stream()
                 .flatMap(tracker -> tracker.getStages().stream())
                 .collect(Collectors.toList());
-        Map<String, SampleStageTracker> requestStagesMap = aggregateStages(sampleStages);
+        Map<String, StageTracker> requestStagesMap = aggregateStages(sampleStages);
         return requestStagesMap;
     }
 
@@ -313,14 +313,14 @@ public class GetRequestTrackingTask {
      * @param sampleStages - List of SampleStageTracker instances representing one stage of one sample
      * @return
      */
-    public Map<String, SampleStageTracker> aggregateStages(List<SampleStageTracker> sampleStages) {
-        Map<String, SampleStageTracker> stageMap = new TreeMap<>(new StageComp());
+    public Map<String, StageTracker> aggregateStages(List<StageTracker> sampleStages) {
+        Map<String, StageTracker> stageMap = new TreeMap<>(new StageComp());
         if (sampleStages.size() == 0) return stageMap;
 
         String stageName;
-        SampleStageTracker projectStage;    // SampleStageTracker of the project created from aggregated sampleStages
+        StageTracker projectStage;    // SampleStageTracker of the project created from aggregated sampleStages
         Boolean isFailedStage;
-        for (SampleStageTracker sampleStage : sampleStages) {
+        for (StageTracker sampleStage : sampleStages) {
             stageName = sampleStage.getStage();
             // Merge Event - Stage added by a previous ProjectSample
             if (stageMap.containsKey(stageName)) {
@@ -328,7 +328,7 @@ public class GetRequestTrackingTask {
                 projectStage.updateStageTimes(sampleStage);
                 projectStage.addStartingSample(SAMPLE_COUNT);
             } else {
-                projectStage = new SampleStageTracker(stageName, SAMPLE_COUNT, 0, sampleStage.getStartTime(), sampleStage.getUpdateTime());
+                projectStage = new StageTracker(stageName, SAMPLE_COUNT, 0, sampleStage.getStartTime(), sampleStage.getUpdateTime());
                 stageMap.put(stageName, projectStage);
             }
             isFailedStage = sampleStage.getFailedSamplesCount() > 0;
@@ -349,8 +349,8 @@ public class GetRequestTrackingTask {
          */
         Boolean complete = true;
         Integer completedCount;
-        Collection<SampleStageTracker> trackers = stageMap.values();
-        for (SampleStageTracker tracker : trackers) {
+        Collection<StageTracker> trackers = stageMap.values();
+        for (StageTracker tracker : trackers) {
             completedCount = tracker.getEndingSamples() + tracker.getFailedSamplesCount();
             complete = complete && completedCount.equals(tracker.getSize());
             tracker.setComplete(complete);
@@ -367,7 +367,7 @@ public class GetRequestTrackingTask {
      * @param drm
      * @return
      */
-    private SampleStageTracker getSubmittedStage(String serviceId, User user, DataRecordManager drm) {
+    private StageTracker getSubmittedStage(String serviceId, User user, DataRecordManager drm) {
         Map<String, Integer> tracker = new HashMap<>();
 
         String query = String.format("%s = '%s'", BankedSampleModel.SERVICE_ID, serviceId);
@@ -398,7 +398,7 @@ public class GetRequestTrackingTask {
         total = tracker.get("Total");
         promoted = tracker.get(BankedSampleModel.PROMOTED);
 
-        SampleStageTracker requestStage = new SampleStageTracker(STAGE_SUBMITTED, total, promoted, null, null);
+        StageTracker requestStage = new StageTracker(STAGE_SUBMITTED, total, promoted, null, null);
         Boolean submittedComplete = total == promoted;
         if (submittedComplete) {
             requestStage.setComplete(Boolean.TRUE);

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSample.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSample.java
@@ -21,7 +21,7 @@ public class ProjectSample {
     DataRecord record;
     boolean complete;
     Boolean failed;
-    private Map<String, SampleStageTracker> stages;     // Stages present in the project
+    private Map<String, StageTracker> stages;     // Stages present in the project
     private WorkflowSample root;                        // workflowSamples descend from tree root
 
     public ProjectSample(Long recordId) {
@@ -54,7 +54,7 @@ public class ProjectSample {
         this.failed = failed;
     }
 
-    public List<SampleStageTracker> getStages() {
+    public List<StageTracker> getStages() {
         return new ArrayList(stages.values());
     }
 
@@ -64,11 +64,11 @@ public class ProjectSample {
      *
      * @param stages
      */
-    public void addStages(List<SampleStageTracker> stages) {
+    public void addStages(List<StageTracker> stages) {
         stages.forEach(
                 (stage) -> {
                     this.stages.merge(
-                            stage.getStage(), stage, (SampleStageTracker currentStage, SampleStageTracker updateStage) -> {
+                            stage.getStage(), stage, (StageTracker currentStage, StageTracker updateStage) -> {
                                 currentStage.updateStageTimes(updateStage);
                                 return currentStage;
                             });

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSampleTree.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSampleTree.java
@@ -111,7 +111,7 @@ public class ProjectSampleTree {
                 stage = this.stageMap.get(stageName);
                 stage.updateStageTimes(node);
             } else {
-                stage = new StageTracker(stageName, 1, 0, node.getStartTime(), node.getUpdateTime());
+                stage = new StageTracker(stageName, StageTracker.SAMPLE_COUNT, 0, node.getStartTime(), node.getUpdateTime());
                 this.stageMap.put(stageName, stage);
             }
         } else {
@@ -178,7 +178,7 @@ public class ProjectSampleTree {
     public void updateTreeOnLeafStatus(WorkflowSample leaf) {
         StageTracker stage = this.stageMap.computeIfAbsent(leaf.getStage(),
                 // Absent when the LIMS tree is a single node in "Awaiting Processing"
-                k -> new StageTracker(STAGE_AWAITING_PROCESSING, 1, 0, 0L, 0L));
+                k -> new StageTracker(STAGE_AWAITING_PROCESSING, StageTracker.SAMPLE_COUNT, 0, 0L, 0L));
 
         // Failed leafs do not modify the completion status
         if (leaf.getFailed()) {

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/Request.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/Request.java
@@ -18,7 +18,7 @@ public class Request {
 
     private String requestId;
     private String bankedSampleId;
-    private Map<String, SampleStageTracker> stages;
+    private Map<String, StageTracker> stages;
     private List<ProjectSample> samples;                // Tree of samples
     private Map<String, Object> metaData;               // Summary of metaData
     private Map<String, Object> summary;                // Summary of overall project status
@@ -46,16 +46,16 @@ public class Request {
      * @param stageName
      * @param stage
      */
-    public void addStage(String stageName, SampleStageTracker stage) {
+    public void addStage(String stageName, StageTracker stage) {
         if (this.stages.containsKey(stageName)) {
             log.warn(String.format("Overriding stage: %s recorded for record: %s", stageName, this.requestId));
         }
         this.stages.put(stageName, stage);
     }
 
-    public Map<String, SampleStageTracker> getStages() {
-        Map<String, SampleStageTracker> cloned = new TreeMap<>(new StageComp());
-        for(Map.Entry<String, SampleStageTracker> entry : this.stages.entrySet()){
+    public Map<String, StageTracker> getStages() {
+        Map<String, StageTracker> cloned = new TreeMap<>(new StageComp());
+        for(Map.Entry<String, StageTracker> entry : this.stages.entrySet()){
             cloned.put(entry.getKey(), entry.getValue());
         }
         return cloned;

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/StageTracker.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/StageTracker.java
@@ -6,20 +6,20 @@ import org.apache.commons.logging.LogFactory;
 import java.util.Map;
 
 /**
- * Represents a Tracked Stage in IGO's project tracker
+ * Represents a Tracked Stage in IGO's project tracker at either the sample-level (size 1) or request level (size >= 1)
  * Notes:
  * - Stages are initialized as complete
  * - Failed WorkflowSamples are considered to have "completed" that stage and do not set a stage to incomplete
  *
  * @author David Streid
  */
-public class SampleStageTracker extends StatusTracker {
-    private static Log log = LogFactory.getLog(SampleStageTracker.class);
+public class StageTracker extends StatusTracker {
+    private static Log log = LogFactory.getLog(StageTracker.class);
 
     private Integer endingSamples;      // Number of samples that have completed this stage and moved on to the next
     private Integer failedSamples;      // Number of failed samples at this stage (considered incomplete)
 
-    public SampleStageTracker(String stage, Integer size, Integer endingSamples, Long startTime, Long updateTime) {
+    public StageTracker(String stage, Integer size, Integer endingSamples, Long startTime, Long updateTime) {
         this.complete = Boolean.TRUE;   // Stages default to complete. Only an update can set to incomplete
         this.endingSamples = endingSamples;
         this.failedSamples = 0;

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/StageTracker.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/StageTracker.java
@@ -15,6 +15,7 @@ import java.util.Map;
  */
 public class StageTracker extends StatusTracker {
     private static Log log = LogFactory.getLog(StageTracker.class);
+    public static final Integer SAMPLE_COUNT = 1; // Default size for a sample, i.e. single tracked sample has size: 1
 
     private Integer endingSamples;      // Number of samples that have completed this stage and moved on to the next
     private Integer failedSamples;      // Number of failed samples at this stage (considered incomplete)


### PR DESCRIPTION
Refactored SampleStageTracker to StageTracker and used SAMPLE_COUNT wherever StageTracker is initialized, except for when it's tracking the stages at the request level (with multiple samples)