### PR TITLE
Same igoComplete logic for /getIgoRequests & /getRequestTracking

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -159,31 +159,6 @@ public class GetRequestTrackingTask {
     }
 
     /**
-     * Returns whether a project is considered IGO-complete.
-     * Criteria:
-     *      Extraction Requests - 1) Status: "Completed", 2) Non-null Completed Date
-     *      Other - Non-null Recent Delivery Date
-     *
-     * @param record
-     * @param user
-     * @return
-     */
-    private boolean isIgoComplete(DataRecord record, User user) {
-        Long mostRecentDeliveryDate = getRecordLongValue(record, RequestModel.RECENT_DELIVERY_DATE, user);
-        if (mostRecentDeliveryDate != null) {
-            return true;
-        }
-
-        // Extraction requests are determined complete by having a "Completed" status w/ a completion date
-        String recordName = getRecordStringValue(record, RequestModel.DATA_RECORD_NAME, user);
-        Long completedDate = getRecordLongValue(record, RequestModel.COMPLETED_DATE, user);
-        String status = getRecordStringValue(record, "Status", user);
-        return recordName.toLowerCase().contains("extraction") &&
-                completedDate != null &&
-                status.toLowerCase().contains("completed");
-    }
-
-    /**
      * Traverse the tree of each "Sample" DataType child of the input @requestRecord. This tree is converted into
      * a ProjectSample data model that represents the tree
      *

--- a/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
+++ b/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
@@ -33,6 +33,7 @@ public class RequestSummary {
     private String labHeadEmail;
     private String qcAccessEmail;
     private String dataAccessEmails;
+    private Boolean isIgoComplete;
 
     public RequestSummary() {
         this("UNKNOWN");
@@ -95,6 +96,15 @@ public class RequestSummary {
 
     public void setLabHeadEmail(String labHeadEmail) {
         this.labHeadEmail = labHeadEmail;
+    }
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    public Boolean getIsIgoComplete() {
+        return this.isIgoComplete;
+    }
+
+    public void setIsIgoComplete(Boolean isIgoComplete) {
+        this.isIgoComplete = isIgoComplete;
     }
 
     public void setRestStatus(String s) {

--- a/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
+++ b/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
@@ -3,13 +3,18 @@ package org.mskcc.limsrest.util;
 import java.rmi.RemoteException;
 import java.util.*;
 
+import com.velox.api.datarecord.DataRecord;
 import com.velox.api.user.User;
 import com.velox.api.util.ServerException;
 import com.velox.api.workflow.Workflow;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
+import com.velox.sloan.cmo.recmodels.RequestModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mskcc.limsrest.ConnectionLIMS;
+
+import static org.mskcc.limsrest.util.Utils.getRecordLongValue;
+import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
 
 /**
  * Logic for determining and ordering stages from LIMS sample statuses and workflows
@@ -106,6 +111,28 @@ public class StatusTrackerConfig {
             return p1 - p2;
         }
     }
+
+    /**
+     * Returns whether a project is considered IGO-complete.
+     * Criteria:
+     *      Extraction Requests - 1) Status: "Completed", 2) Non-null Completed Date
+     *      Other - Non-null Recent Delivery Date
+     *
+     * @param record
+     * @param user
+     * @return
+     */
+    public static boolean isIgoComplete(DataRecord record, User user) {
+        Long mostRecentDeliveryDate = getRecordLongValue(record, RequestModel.RECENT_DELIVERY_DATE, user);
+        if (mostRecentDeliveryDate != null) {
+            return true;
+        }
+
+        // Other requests are considered complete if they have a completion date
+        Long completedDate = getRecordLongValue(record, RequestModel.COMPLETED_DATE, user);
+        return completedDate != null;
+    }
+
 
     // A Standard ExemplarSampleStatus is composed of a workflow status prefix (below) and workflow name
     public static final String WORKFLOW_STATUS_IN_PROCESS = "In Process - ";

--- a/src/test/java/org/mskcc/limsrest/service/GetIgoRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetIgoRequestsTaskTest.java
@@ -1,0 +1,95 @@
+package org.mskcc.limsrest.service;
+
+import com.velox.api.datarecord.DataRecord;
+import com.velox.api.datarecord.DataRecordManager;
+import com.velox.api.datarecord.IoError;
+import com.velox.api.datarecord.NotFound;
+import com.velox.api.user.User;
+import com.velox.sapioutils.client.standalone.VeloxConnection;
+import com.velox.sloan.cmo.recmodels.RequestModel;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mskcc.limsrest.ConnectionLIMS;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mskcc.limsrest.util.StatusTrackerConfig.isIgoComplete;
+
+public class GetIgoRequestsTaskTest {
+    public final Long DAYS_RANGE = 100l;
+    ConnectionLIMS conn;
+
+    @Before
+    public void setup() {
+        // Connection needed to query the existing tango workflow manager
+        this.conn = new ConnectionLIMS("tango.mskcc.org", 1099, "fe74d8e1-c94b-4002-a04c-eb5c492704ba", "test-runner", "password1");
+    }
+
+    @After
+    public void tearDown() {
+        this.conn.close();
+    }
+
+    private Map<String, DataRecord> getIgoRequestDataRecords(Boolean getCompleteRequests) {
+        VeloxConnection vConn = conn.getConnection();
+        User user = vConn.getUser();
+        DataRecordManager drm = vConn.getDataRecordManager();
+
+        GetIgoRequestsTask task = new GetIgoRequestsTask(DAYS_RANGE, getCompleteRequests);
+        List<RequestSummary> requests = task.execute(vConn);
+
+        Map<String, DataRecord> validatedRecords = new HashMap<>();
+
+        for (RequestSummary request : requests) {
+            String requestId = request.getRequestId();
+            List<DataRecord> records = new ArrayList<>();
+            try {
+                records = drm.queryDataRecords(RequestModel.DATA_TYPE_NAME, String.format("RequestId = '%s'", requestId), user);
+            } catch (NotFound e) {
+                Assert.assertTrue(String.format("Data Record for request Id: %s doesn't exist. Update test", requestId), false);
+            } catch (IoError | RemoteException e) {
+                Assert.assertTrue(String.format("Error getting Data Record for request Id: %s", requestId), false);
+            }
+            if (records.size() != 1) {
+                Assert.assertTrue(String.format("Data Record %s is ambiguous or doesn't exist. Update test"), false);
+            }
+
+            validatedRecords.put(requestId, records.get(0));
+        }
+
+        return validatedRecords;
+    }
+
+    @Test
+    public void getIgoRequestsTask_matchesIsIgoCompleteUtil_incomplete() {
+        Boolean isComplete = Boolean.FALSE;
+        Map<String, DataRecord> dataRecords = getIgoRequestDataRecords(isComplete);
+        Assert.assertTrue("No data records to test. Increase @DAYS_RANGE", dataRecords.size() > 0);
+        for (Map.Entry<String, DataRecord> record : dataRecords.entrySet()) {
+            Assert.assertEquals(String.format("Record Id: %s didn't match expected completion status; %b",
+                    record.getKey(), isComplete),
+                    isComplete,
+                    isIgoComplete(record.getValue(), conn.getConnection().getUser()));
+        }
+    }
+
+    @Test
+    public void getIgoRequestsTask_matchesIsIgoCompleteUtil_complete() {
+        Boolean isComplete = Boolean.TRUE;
+        Map<String, DataRecord> dataRecords = getIgoRequestDataRecords(isComplete);
+        Assert.assertTrue("No data records to test. Increase @DAYS_RANGE", dataRecords.size() > 0);
+        for (Map.Entry<String, DataRecord> record : dataRecords.entrySet()) {
+            Assert.assertEquals(String.format("Record Id: %s didn't match expected completion status; %b",
+                    record.getKey(), isComplete),
+                    isComplete,
+                    isIgoComplete(record.getValue(), conn.getConnection().getUser()));
+        }
+    }
+}
+

--- a/src/test/java/org/mskcc/limsrest/service/GetIgoRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetIgoRequestsTaskTest.java
@@ -66,6 +66,8 @@ public class GetIgoRequestsTaskTest {
         return validatedRecords;
     }
 
+    // DON'T DELETE THESE TESTS. They are run when the logic for determining isIgoComplete changes
+    /*
     @Test
     public void getIgoRequestsTask_matchesIsIgoCompleteUtil_incomplete() {
         Boolean isComplete = Boolean.FALSE;
@@ -91,5 +93,6 @@ public class GetIgoRequestsTaskTest {
                     isIgoComplete(record.getValue(), conn.getConnection().getUser()));
         }
     }
+    */
 }
 


### PR DESCRIPTION
These two endpoints should share the same logic for determining if a request `isIgoComplete` from `StatusTrackerConfig` > `isIgoComplete`.

`/getIgoRequests` returns the summary of igoRequests & `/getRequestTracking` returns each sample-tracking information. It would be bad if for instance `/getIgoRequests` returned "completed" requests for which any returned `isIgoComplete: false` for their `/getRequestTracking` request.

Note - the tests pass, but are commented out due to time it takes to run them. They should be uncommented if the logic changes