### PR TITLE
"CompletedDate" isIgoComplete Check only for Extraction Requests

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetIgoRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetIgoRequestsTask.java
@@ -45,9 +45,9 @@ public class GetIgoRequestsTask extends LimsTask {
              * NOTE - This should be in sync w/ @StatusTrackerConfig::isIgoComplete. If changing this, uncomment
              * @getIgoRequestsTask_matchesIsIgoCompleteUtil_* tests in GetIgoRequestsTaskTest
              */
-            return String.format("%s > %d OR %s > %d",
+            return String.format("%s > %d OR (%s > %d AND lower(%s) LIKE '%%extraction%%')",
                     RequestModel.RECENT_DELIVERY_DATE, searchPoint,
-                    RequestModel.COMPLETED_DATE, searchPoint);
+                    RequestModel.COMPLETED_DATE, searchPoint, RequestModel.REQUEST_TYPE);
         }
         return String.format("%s IS NULL AND %s IS NULL", RequestModel.RECENT_DELIVERY_DATE, RequestModel.COMPLETED_DATE);
     }

--- a/src/main/java/org/mskcc/limsrest/service/GetIgoRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetIgoRequestsTask.java
@@ -35,21 +35,34 @@ public class GetIgoRequestsTask extends LimsTask {
         return now - offset;
     }
 
+    /**
+     * Returns the query to use to retrieve the IGO request
+     *
+     * NOTE - This should be in sync w/ @StatusTrackerConfig::isIgoComplete. If changing this, uncomment
+     * @getIgoRequestsTask_matchesIsIgoCompleteUtil_* tests in GetIgoRequestsTaskTest
+     * @return
+     */
     private String getQuery() {
         long searchPoint = getSearchPoint();
         if (this.igoComplete) {
-            /** IGO completion is determined by,
-             *      1) Request having a recentDelivery date (Sequencing project marked for delivery)
-             *      2) Request having a completed date (all other requests)
-             *
-             * NOTE - This should be in sync w/ @StatusTrackerConfig::isIgoComplete. If changing this, uncomment
-             * @getIgoRequestsTask_matchesIsIgoCompleteUtil_* tests in GetIgoRequestsTaskTest
+            /** IGO completion Criteria:
+             *      1) Request w/ RECENT_DELIVERY_DATE date (Sequencing project marked for delivery)
+             *      2) Extraction Request having a COMPLETED_DATE (all other requests)
              */
             return String.format("%s > %d OR (%s > %d AND lower(%s) LIKE '%%extraction%%')",
                     RequestModel.RECENT_DELIVERY_DATE, searchPoint,
-                    RequestModel.COMPLETED_DATE, searchPoint, RequestModel.REQUEST_TYPE);
+                    RequestModel.COMPLETED_DATE, searchPoint, RequestModel.REQUEST_NAME);
         }
-        return String.format("%s IS NULL AND %s IS NULL", RequestModel.RECENT_DELIVERY_DATE, RequestModel.COMPLETED_DATE);
+        /** IGO incomplete Criteria:
+         *      1) No RECENT_DELIVERY_DATE (Sequencing project NOT marked for delivery)
+         *      2) Extraction requests w/o a COMPLETED_DATE
+         * NOTE: DATE_CREATED is used because sometimes ReceivedDate can be null
+         */
+        return String.format("%s > %d AND NOT ((%s IS NOT NULL) OR (%s IS NOT NULL AND %s LIKE '%%extraction%%'))",
+                RequestModel.DATE_CREATED, searchPoint,
+                RequestModel.RECENT_DELIVERY_DATE,
+                RequestModel.COMPLETED_DATE,
+                RequestModel.REQUEST_NAME);
     }
 
     @PreAuthorize("hasRole('READ')")

--- a/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
+++ b/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
@@ -12,6 +12,7 @@ import com.velox.sloan.cmo.recmodels.RequestModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mskcc.limsrest.ConnectionLIMS;
+import org.mskcc.limsrest.service.requesttracker.Request;
 
 import static org.mskcc.limsrest.util.Utils.getRecordLongValue;
 import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
@@ -118,6 +119,8 @@ public class StatusTrackerConfig {
      *      Extraction Requests - 1) Status: "Completed", 2) Non-null Completed Date
      *      Other - Non-null Recent Delivery Date
      *
+     * NOTE - This should be in sync w/ @StatusTrackerConfig::isIgoComplete. If changing this, uncomment
+     * @getIgoRequestsTask_matchesIsIgoCompleteUtil_* tests in GetIgoRequestsTaskTest
      * @param record
      * @param user
      * @return
@@ -128,9 +131,10 @@ public class StatusTrackerConfig {
             return true;
         }
 
-        // Other requests are considered complete if they have a completion date
+        // Extraction requests ONLY are considered complete if they have a completion date
         Long completedDate = getRecordLongValue(record, RequestModel.COMPLETED_DATE, user);
-        return completedDate != null;
+        String requestType = getRecordStringValue(record, RequestModel.REQUEST_TYPE, user);
+        return (completedDate != null) && requestType.toLowerCase().contains("extraction");
     }
 
 

--- a/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
+++ b/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
@@ -133,7 +133,7 @@ public class StatusTrackerConfig {
 
         // Extraction requests ONLY are considered complete if they have a completion date
         Long completedDate = getRecordLongValue(record, RequestModel.COMPLETED_DATE, user);
-        String requestType = getRecordStringValue(record, RequestModel.REQUEST_TYPE, user);
+        String requestType = getRecordStringValue(record, RequestModel.REQUEST_NAME, user);
         return (completedDate != null) && requestType.toLowerCase().contains("extraction");
     }
 

--- a/src/test/java/org/mskcc/limsrest/service/GetIgoRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetIgoRequestsTaskTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import static org.mskcc.limsrest.util.StatusTrackerConfig.isIgoComplete;
 
 public class GetIgoRequestsTaskTest {
-    public final Long DAYS_RANGE = 100l;
+    public final Long DAYS_RANGE = 365l;
     ConnectionLIMS conn;
 
     @Before

--- a/src/test/java/org/mskcc/limsrest/util/StatusTrackerConfigTest.java
+++ b/src/test/java/org/mskcc/limsrest/util/StatusTrackerConfigTest.java
@@ -364,7 +364,8 @@ public class StatusTrackerConfigTest {
         DataRecordManager drm = vConn.getDataRecordManager();
 
         Map<String, Boolean> testCases = new HashMap<>();
-        testCases.put("09716_I", Boolean.TRUE);     // Has "Completed Date"
+        testCases.put("07527_J", Boolean.TRUE);     // Extraction request w/ "Completed Date"
+        testCases.put("09657", Boolean.TRUE);       // RNA Extraction request w/ "Completed Date"
         testCases.put("09443_S", Boolean.TRUE);     // Has "Most Recent Delivery Date"
         testCases.put("09348_B", Boolean.FALSE);    // Has neither
 
@@ -385,7 +386,7 @@ public class StatusTrackerConfigTest {
                 Assert.assertTrue(String.format("Data Record %s is ambiguous or doesn't exist. Update test"), false);
             }
 
-            Assert.assertEquals(expectedResult, isIgoComplete(records.get(0), user));
+            Assert.assertEquals(String.format("Request Id: %s should have been %b", requestId, expectedResult), expectedResult, isIgoComplete(records.get(0), user));
         }
     }
 


### PR DESCRIPTION
BEFORE: Any request w/ a completed date is considered IgoComplete
AFTER: Only extraction requests meeting this criteria (w/ a completed date) are considered IgoComplete
- Sequencing requests can be marked complete, but aren't igoComplete until their Data Quality Control record is marked "IGO-COMPLETE" in the run-qc website