### PR TITLE
Sequencing is complete only if IGO-Complete 

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -214,11 +214,12 @@ public class GetRequestTrackingTask {
     private ProjectSampleTree createWorkflowTree(WorkflowSample root, ProjectSampleTree tree) {
         tree.addStageToTracked(root);   // Update tree Project Sample stages w/ the input Workflow sample's stage
 
-        if (STAGE_DATA_QC.equals(root.getStage()) && !tree.isPassedDataQc()) {
+        if (STAGE_DATA_QC.equals(root.getStage()) && !tree.isQcIgoComplete()) {
             // The Data QC stage is updated by a node in Data QC stage. This node can update the entire tree's data
             // QC status as a ProjectSample is marked Data QC complete if it has any one Data QC node marked passed
             tree.updateDataQcStage(root);
         }
+        // TODO - Add logic for when this is in the extraction stage
 
         // Search each child of the input
         DataRecord[] children = new DataRecord[0];

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSampleTree.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSampleTree.java
@@ -48,11 +48,11 @@ public class ProjectSampleTree {
         return root;
     }
 
-    public Boolean isQcIgoComplete() {
+    public boolean isQcIgoComplete() {
         return QcStatus.IGO_COMPLETE.toString().equalsIgnoreCase(this.dataQcStatus);
     }
 
-    public Boolean isFailedDataQC() {
+    public boolean isFailedDataQC() {
         return SEQ_QC_STATUS_FAILED.equalsIgnoreCase(this.dataQcStatus);
     }
 

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSampleTree.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSampleTree.java
@@ -1,14 +1,14 @@
 package org.mskcc.limsrest.service.requesttracker;
 
+import java.util.*;
 import com.velox.api.datarecord.DataRecord;
 import com.velox.api.user.User;
 import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import java.util.*;
-
+import org.mskcc.limsrest.service.assignedprocess.QcStatus;
 import static org.mskcc.limsrest.util.StatusTrackerConfig.*;
+import static org.mskcc.limsrest.util.StatusTrackerConfig.isQcStatusIgoComplete;
 import static org.mskcc.limsrest.util.Utils.*;
 
 /**
@@ -48,8 +48,8 @@ public class ProjectSampleTree {
         return root;
     }
 
-    public Boolean isPassedDataQc() {
-        return SEQ_QC_STATUS_PASSED.equalsIgnoreCase(this.dataQcStatus);
+    public Boolean isQcIgoComplete() {
+        return QcStatus.IGO_COMPLETE.toString().equalsIgnoreCase(this.dataQcStatus);
     }
 
     public Boolean isFailedDataQC() {
@@ -67,7 +67,7 @@ public class ProjectSampleTree {
      * @param status
      */
     private void setDataQcStatus(String status) {
-        if (SEQ_QC_STATUS_PASSED.equals(this.dataQcStatus)) {
+        if (QcStatus.IGO_COMPLETE.toString().equals(this.dataQcStatus)) {
             log.warn(String.format("Not re-seting Tree dataQcStatus to %s. Sample has already been DataQC %s",
                     status, SEQ_QC_STATUS_PASSED));
             return;
@@ -132,15 +132,15 @@ public class ProjectSampleTree {
         }
 
         // Attempt to update the Data Qc Status of the tree if the current status isn't Passed
-        boolean isPassedDataQc = isPassedDataQc();
-        if (!isPassedDataQc) {
+        boolean isIgoComplete = isQcIgoComplete();
+        if (!isIgoComplete) {
             updateDataQcStatus(node.getRecord());
-            isPassedDataQc = isPassedDataQc();          // After @updateDataQcStatus, update this flag
+            isIgoComplete = isQcIgoComplete();          // After @updateDataQcStatus, update this flag
         }
 
         // Update the Tree Data QC Stage
         StageTracker dataQcStage = this.stageMap.get(nodeStage);
-        dataQcStage.setComplete(isPassedDataQc);
+        dataQcStage.setComplete(isIgoComplete);
 
         // If the input @node had a Failed Data QC child, the Workflow Sample branch needs to be failed
         if (isFailedDataQC()) {
@@ -157,15 +157,24 @@ public class ProjectSampleTree {
      * @return
      */
     private void updateDataQcStatus(DataRecord record) {
-        DataRecord[] sampleQcRecord = getChildrenofDataRecord(record, SeqAnalysisSampleQCModel.DATA_TYPE_NAME, this.user);
-        if (sampleQcRecord.length == 0) {
+        DataRecord[] sampleQcRecords = getChildrenofDataRecord(record, SeqAnalysisSampleQCModel.DATA_TYPE_NAME, this.user);
+        if (sampleQcRecords.length == 0) {
             // Only a node in the Data QC stage will have a child instance of the SeqAnalysisSampleQC DataType
             return;
         }
-        String seqQcStatus = getRecordStringValue(sampleQcRecord[0], SeqAnalysisSampleQCModel.SEQ_QCSTATUS, this.user);
-        boolean isValidStatus = !"".equals(seqQcStatus);
-        if (isValidStatus) {
-            setDataQcStatus(seqQcStatus);
+
+        DataRecord sampleQcRecord = sampleQcRecords[0];
+        Boolean isIgoComplete = isQcStatusIgoComplete(sampleQcRecord, this.user);
+        if(isIgoComplete){
+            // Mark "IGO-Complete" because this is not a valid @SEQ_QCSTATUS value. LIMS differentiates a "Passed" &
+            // "IGO-Complete" DataQc record by their "DateIgoComplete" value, not their @SEQ_QCSTATUS value
+            setDataQcStatus(QcStatus.IGO_COMPLETE.toString());
+        } else {
+            String seqQcStatus = getRecordStringValue(sampleQcRecord, SeqAnalysisSampleQCModel.SEQ_QCSTATUS, this.user);
+            boolean isValidStatus = !"".equals(seqQcStatus);
+            if (isValidStatus) {
+                setDataQcStatus(seqQcStatus);
+            }
         }
     }
 
@@ -185,7 +194,7 @@ public class ProjectSampleTree {
             markFailedBranch(leaf);
         } else {
             // If the sample has been recorded as completed sequencing, then the leaf node is completed
-            if (isPassedDataQc()) {
+            if (isQcIgoComplete()) {
                 leaf.setComplete(Boolean.TRUE);   // Default leaf completion state is FALSE
                 stage.setComplete(Boolean.TRUE);  // Reset incompleted stages to true since sequencing is the last step
             } else {

--- a/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
+++ b/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
@@ -9,13 +9,13 @@ import com.velox.api.util.ServerException;
 import com.velox.api.workflow.Workflow;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
 import com.velox.sloan.cmo.recmodels.RequestModel;
+import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mskcc.limsrest.ConnectionLIMS;
-import org.mskcc.limsrest.service.requesttracker.Request;
+import org.mskcc.limsrest.service.assignedprocess.QcStatus;
 
-import static org.mskcc.limsrest.util.Utils.getRecordLongValue;
-import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
+import static org.mskcc.limsrest.util.Utils.*;
 
 /**
  * Logic for determining and ordering stages from LIMS sample statuses and workflows
@@ -135,6 +135,28 @@ public class StatusTrackerConfig {
         Long completedDate = getRecordLongValue(record, RequestModel.COMPLETED_DATE, user);
         String requestType = getRecordStringValue(record, RequestModel.REQUEST_NAME, user);
         return (completedDate != null) && requestType.toLowerCase().contains("extraction");
+    }
+
+    /**
+     * This should match ToggleSampleQcStatus > setSeqAnalysisSampleQcStatus
+     * @param record
+     * @param user
+     * @return
+     */
+    public static boolean isQcStatusIgoComplete(DataRecord record, User user) {
+        Boolean passedQc = getRecordBooleanValue(record, SeqAnalysisSampleQCModel.PASSED_QC, user);
+        if(!passedQc){
+            return false;
+        }
+        String seqQcStatus = getRecordStringValue(record, SeqAnalysisSampleQCModel.SEQ_QCSTATUS, user);
+        if(!QcStatus.PASSED.getText().equals(seqQcStatus)){
+            return false;
+        }
+        return true;
+        /* TODO - True for samples after 2/20/20. Add after Feb 2021
+        Long dateIgoComplete = getRecordLongValue(record, "DateIgoComplete", user);
+        return dateIgoComplete != null;
+         */
     }
 
 

--- a/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
@@ -24,6 +24,7 @@ public class GetRequestTrackingTaskTest {
             "09367_K",      // Good:    Failed branches                 1 IGO-Complete
             "07428_AA",     // Good:    Includes extraction             4 IGO-Complete
             "06302_Z",      // Good:    Submitted Stage has non-promoted record
+
             // Passed/Pending
             "10793",        // Good: 9 Passed, 1 Pending
 
@@ -110,8 +111,8 @@ public class GetRequestTrackingTaskTest {
                 new ProjectBuilder("10793")
                         .addStage(STAGE_SUBMITTED, true, 10, 10, 0)
                         .addStage(STAGE_LIBRARY_PREP, true, 10, 10, 0)
-                        .addStage(STAGE_SEQUENCING, false, 10, 9, 0)
-                        .addStage(STAGE_DATA_QC, false, 10, 9, 0)
+                        .addStage(STAGE_SEQUENCING, false, 10, 0, 0)  // Passed, not complete
+                        .addStage(STAGE_DATA_QC, false, 10, 0, 0)
                         .build()));
 
         testProjects(testCases);


### PR DESCRIPTION
* Determining IGO-Complete status based on same criteria as `ToggleSampleQcStatus` > `setSeqAnalysisSampleQcStatus`, the method that markes "IGO-complete" from the run-qc website
* Only considering a Sample to be finished w/ sequencing if it has IGO-Complete status on its DataQC record, before was just "Passed". "Passed" doesn't take into account when a sample needs to be repooled for which all DataQC records will be "Passed" while the repooled sample is still being processed and the sample as a whole is incomplete