### PR TITLE
Updating isSequencingComplete to use isQcStatusIgoComplete

### DIFF
--- a/src/main/java/org/mskcc/limsrest/util/Utils.java
+++ b/src/main/java/org/mskcc/limsrest/util/Utils.java
@@ -87,8 +87,13 @@ public class Utils {
         if (qcRecord.length == 0) {
             return false;
         }
+
+        DataRecord record = qcRecord[0];
+        Boolean isComplete = isQcStatusIgoComplete(record, user);
         String sequencingStatus = getRecordStringValue(qcRecord[0], SeqAnalysisSampleQCModel.SEQ_QCSTATUS, user);
-        return sequencingStatus.equalsIgnoreCase(SEQ_QC_STATUS_PASSED) || sequencingStatus.equalsIgnoreCase(SEQ_QC_STATUS_FAILED);
+        Boolean isFailed = sequencingStatus.equalsIgnoreCase(SEQ_QC_STATUS_FAILED);
+
+        return isComplete || isFailed;
     }
 
     /**


### PR DESCRIPTION
**Change:** 
Using `isQcStatusIgoComplete` to determine if a sample has completed sequencing because it checks whether the data record's `PassedQc` flag is set to true.
- For cases like a "Top-Up", the sample can be "Passed", but the sequencing is not complete

**Background:**
When a sample is marked "IGO-Complete", the method `ToggleSampleQcStatus` >  `setSeqAnalysisSampleQcStatus` is executed, this modifies both the `PassedQc` & `SeqQCStatus` fields of the DataQc record. However, both "Passed" and "IGO-Complete" will have a `SeqQCStatus == "Passed"` so determining whether sequencing is actually done should be based on whether the `PassedQc` flag is set to true, which is what the added `isQcStatusIgoComplete` method does.