### PR TITLE
Removing ChildRequests from the sourceRequest tracking

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -239,7 +239,7 @@ public class GetRequestTrackingTask {
             // Add all data for the root's children at that level. Allows us to fail only the failed branch
             List<WorkflowSample> workflowChildren = new ArrayList<>();
             for (DataRecord record : children) {
-                if(isWorkflowSampleInProject(record, this.requestId, this.user)){
+                if (isWorkflowSampleInProject(record, this.requestId, this.user)) {
                     WorkflowSample sample = new WorkflowSample(record, this.conn);
                     sample.setParent(root);
                     if (STAGE_AWAITING_PROCESSING.equals(sample.getStage())) {

--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -48,10 +48,12 @@ public class GetRequestTrackingTask {
     };
     private ConnectionLIMS conn;
     private String requestId;
+    private User user;
 
     public GetRequestTrackingTask(String requestId, ConnectionLIMS conn) {
         this.requestId = requestId;
         this.conn = conn;
+        this.user = conn.getConnection().getUser();
     }
 
     public Map<String, Object> execute() throws IoError, RemoteException, NotFound {
@@ -237,18 +239,24 @@ public class GetRequestTrackingTask {
             // Add all data for the root's children at that level. Allows us to fail only the failed branch
             List<WorkflowSample> workflowChildren = new ArrayList<>();
             for (DataRecord record : children) {
-                WorkflowSample sample = new WorkflowSample(record, this.conn);
-                sample.setParent(root);
-                if (STAGE_AWAITING_PROCESSING.equals(sample.getStage())) {
-                    // Update the stage of the sample to the parent stage if it is awaitingProcessing. If there is not
-                    // resolved parent, leave as "Awaiting Processing"
-                    if (!STAGE_AWAITING_PROCESSING.equals(root.getStage())) {
-                        sample.setStage(root.getStage());
+                if(isWorkflowSampleInProject(record, this.requestId, this.user)){
+                    WorkflowSample sample = new WorkflowSample(record, this.conn);
+                    sample.setParent(root);
+                    if (STAGE_AWAITING_PROCESSING.equals(sample.getStage())) {
+                        // Update the stage of the sample to the parent stage if it is awaitingProcessing. If there is not
+                        // resolved parent, leave as "Awaiting Processing"
+                        if (!STAGE_AWAITING_PROCESSING.equals(root.getStage())) {
+                            sample.setStage(root.getStage());
+                        }
                     }
+                    root.addChild(sample);
+                    tree.addSample(sample);
+                    workflowChildren.add(sample);
+                } else {
+                    // Child is from a different project - add it as a child Sample Id
+                    String childSampleId = getRecordStringValue(record, SampleModel.SAMPLE_ID, this.user);
+                    root.setChildSampleId(childSampleId);
                 }
-                root.addChild(sample);
-                tree.addSample(sample);
-                workflowChildren.add(sample);
             }
 
             for (WorkflowSample sample : workflowChildren) {
@@ -259,6 +267,21 @@ public class GetRequestTrackingTask {
             }
         }
         return tree;
+    }
+
+    /**
+     * Returns whether the sample is part of the project based on whether the sampleId contains the requestId
+     *      e.g.
+     *          SampleId: "09641_U_76", RequestId: "09641_U" -> TRUE
+     *          SampleId: "09641_X_76", RequestId: "09641_U" -> FALSE
+     * @param record
+     * @param requestId
+     * @param user
+     * @return
+     */
+    private boolean isWorkflowSampleInProject(DataRecord record, String requestId, User user) {
+        String sampleId = getRecordStringValue(record, SampleModel.SAMPLE_ID, user);
+        return sampleId.contains(requestId);
     }
 
     /**
@@ -456,10 +479,18 @@ public class GetRequestTrackingTask {
 
         // Certain fields can only be collected after the ProjectSample has been created
         Set<String> sourceProjects = projectSamples.stream()
-                .map(sample -> sample.getRoot().getSourceRequest())
+                .map(sample -> sample.getRoot().getSourceRequestId())
                 .filter(sampleId -> !StringUtils.isBlank(sampleId))
                 .collect(Collectors.toSet());
         metaData.put("sourceProjects", sourceProjects.toArray());
+
+        // Certain fields can only be collected after the ProjectSample has been created
+        Set<String> childRequests = projectSamples.stream()
+                .map(sample -> sample.getRoot().getChildRequestIds())
+                .flatMap(List::stream)
+                .filter(sampleId -> !StringUtils.isBlank(sampleId))
+                .collect(Collectors.toSet());
+        metaData.put("childRequests", childRequests.toArray());
 
         return metaData;
     }

--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -478,11 +478,11 @@ public class GetRequestTrackingTask {
         metaData.put("serviceId", serviceId);
 
         // Certain fields can only be collected after the ProjectSample has been created
-        Set<String> sourceProjects = projectSamples.stream()
+        Set<String> sourceRequests = projectSamples.stream()
                 .map(sample -> sample.getRoot().getSourceRequestId())
                 .filter(sampleId -> !StringUtils.isBlank(sampleId))
                 .collect(Collectors.toSet());
-        metaData.put("sourceProjects", sourceProjects.toArray());
+        metaData.put("sourceRequests", sourceRequests.toArray());
 
         // Certain fields can only be collected after the ProjectSample has been created
         Set<String> childRequests = projectSamples.stream()

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/WorkflowSample.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/WorkflowSample.java
@@ -146,11 +146,11 @@ public class WorkflowSample extends StatusTracker {
      */
     public String getRequestFromSampleId(String sampleId) {
         // Source sample ID has suffix, e.g. "06302_X_1358_1_1". We need to parse out the project, e.g. "06302_X"
-        if(!StringUtils.isBlank(sampleId)){
+        if (!StringUtils.isBlank(sampleId)) {
             String pattern = "\\d{5}_[A-Z,a-z]{1,2}";
             Pattern r = Pattern.compile(pattern);
             Matcher m = r.matcher(sampleId);
-            if(m.find()){
+            if (m.find()) {
                 return m.group(0);
             }
             return "INVALID";
@@ -160,6 +160,7 @@ public class WorkflowSample extends StatusTracker {
 
     /**
      * Retrieves a list of the child requestIds for all samples in the subtree of this instance of a WorkflowSample
+     *
      * @return - All the child RequestIds (taken from SampleIds) descended from this
      */
     public List<String> getChildRequestIds() {
@@ -167,16 +168,17 @@ public class WorkflowSample extends StatusTracker {
         Queue<WorkflowSample> queue = new LinkedList<>();
         queue.add(this);
 
+        // BFS of samples descending from root sample
         WorkflowSample nxt;
-        while(queue.size() > 0){
+        while (queue.size() > 0) {
             nxt = queue.remove();
             childSampleIds.add(nxt.getChildSampleId());
             queue.addAll(nxt.getChildren());
         }
 
         return childSampleIds.stream()
-                      .map(sampleId -> getRequestFromSampleId(sampleId))
-                      .collect(Collectors.toList());
+                .map(sampleId -> getRequestFromSampleId(sampleId))
+                .collect(Collectors.toList());
     }
 
     public String getSourceRequestId() {

--- a/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
@@ -227,7 +227,7 @@ public class GetRequestTrackingTaskTest {
     }
 
     @Test
-    public void sourceProject() {
+    public void sourceRequest() {
         String childRequestId = "06302_AB";
         String expectedSourceRequestId = "06302_AA";
         GetRequestTrackingTask t = new GetRequestTrackingTask(childRequestId, this.conn);
@@ -239,9 +239,9 @@ public class GetRequestTrackingTaskTest {
         }
 
         Map<String, Object> metaData = (Map<String, Object>) requestInfo.get("metaData");
-        Object[] sourceProjectList = (Object[]) metaData.get("sourceProjects");
-        assertEquals(String.format("%s should have one source request", childRequestId), sourceProjectList.length, 1);
-        String actualSourceRequest = (String) sourceProjectList[0];
+        Object[] sourceRequestList = (Object[]) metaData.get("sourceRequests");
+        assertEquals(String.format("%s should have one source request", childRequestId), sourceRequestList.length, 1);
+        String actualSourceRequest = (String) sourceRequestList[0];
         assertEquals(String.format("%s's source request should be %s", childRequestId, expectedSourceRequestId), actualSourceRequest, expectedSourceRequestId);
     }
 

--- a/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
@@ -81,18 +81,46 @@ public class GetRequestTrackingTaskTest {
                         .addStage(STAGE_LIBRARY_CAPTURE, true, 1, 1, 0)
                         .addStage(STAGE_SEQUENCING, true, 1, 1, 0)
                         .addStage(STAGE_DATA_QC, true, 1, 1, 0)
-                        .build(),
+                        .build()
+        ));
+
+        testProjects(testCases);
+    }
+
+    @Test
+    public void splitProject_07428() throws Exception {
+        /*  ALL PASSED
+            "07428_AA",     // Extraction
+            "07428_AF",		// Sequencing
+         */
+        List<Project> testCases = new ArrayList<>(Arrays.asList(
                 new ProjectBuilder("07428_AA")
                         .addStage(STAGE_SUBMITTED, true, 4, 4, 0)
                         .addStage(STAGE_EXTRACTION, true, 4, 4, 0)
+                        .build(),
+                new ProjectBuilder("07428_AF")
                         .addStage(STAGE_LIBRARY_PREP, true, 4, 4, 0)
                         .addStage(STAGE_LIBRARY_QC, true, 4, 4, 0)
                         .addStage(STAGE_SEQUENCING, true, 4, 4, 0)
                         .addStage(STAGE_DATA_QC, true, 4, 4, 0)
-                        .build(),
+                        .build()
+        ));
+
+        testProjects(testCases);
+    }
+
+    @Test
+    public void splitProject_06302() throws Exception {
+        /*  ALL PASSED
+            "06302_Z",     // Extraction
+            "06302_AC",		// Sequencing
+         */
+        List<Project> testCases = new ArrayList<>(Arrays.asList(
                 new ProjectBuilder("06302_Z")
                         .addStage(STAGE_SUBMITTED, true, 57, 56, 0)
                         .addStage(STAGE_EXTRACTION, true, 56, 56, 0)
+                        .build(),
+                new ProjectBuilder("06302_AC")
                         .addStage(STAGE_LIBRARY_PREP, true, 56, 56, 0)
                         .addStage(STAGE_SEQUENCING, true, 56, 56, 0)
                         .addStage(STAGE_DATA_QC, true, 56, 56, 0)
@@ -196,6 +224,44 @@ public class GetRequestTrackingTaskTest {
         final Long expectedCompletedDate = 1570468879097L;
         assertEquals(String.format("Completion date should be %d", expectedCompletedDate), expectedCompletedDate, completedDate);
         assertTrue("Extraction request should be IGO-Complete", isIgoComplete);
+    }
+
+    @Test
+    public void sourceProject() {
+        String childRequestId = "06302_AB";
+        String expectedSourceRequestId = "06302_AA";
+        GetRequestTrackingTask t = new GetRequestTrackingTask(childRequestId, this.conn);
+        Map<String, Object> requestInfo = new HashMap<>();
+        try {
+            requestInfo = t.execute();
+        } catch (IoError | RemoteException | NotFound e) {
+            assertTrue("Exception in task execution", false);
+        }
+
+        Map<String, Object> metaData = (Map<String, Object>) requestInfo.get("metaData");
+        Object[] sourceProjectList = (Object[]) metaData.get("sourceProjects");
+        assertEquals(String.format("%s should have one source request", childRequestId), sourceProjectList.length, 1);
+        String actualSourceRequest = (String) sourceProjectList[0];
+        assertEquals(String.format("%s's source request should be %s", childRequestId, expectedSourceRequestId), actualSourceRequest, expectedSourceRequestId);
+    }
+
+    @Test
+    public void childProject() {
+        String sourceRequestId = "06302_AA";
+        String expectedChildRequestId = "06302_AB";
+        GetRequestTrackingTask t = new GetRequestTrackingTask(sourceRequestId, this.conn);
+        Map<String, Object> requestInfo = new HashMap<>();
+        try {
+            requestInfo = t.execute();
+        } catch (IoError | RemoteException | NotFound e) {
+            assertTrue("Exception in task execution", false);
+        }
+
+        Map<String, Object> metaData = (Map<String, Object>) requestInfo.get("metaData");
+        Object[] childRequestList = (Object[]) metaData.get("childRequests");
+        assertEquals(String.format("%s should have one child request", sourceRequestId), childRequestList.length, 1);
+        String actualChildRequest = (String) childRequestList[0];
+        assertEquals(String.format("%s's child request should be %s", sourceRequestId, expectedChildRequestId), actualChildRequest, expectedChildRequestId);
     }
 
     /**


### PR DESCRIPTION
Excluding ChildRequests from the sample tracking of the source request
* e.g. Excluding "07428_AF" (sequencing) from "07428_AA" (Extraction)
* This altered some of the tests that tracked the samples from all IGO DataRecord Sample children that descended from the root sample
* Also, "childProjects" -> "childRequest" in response

See the `splitProject_` tests