### PR TITLE
Adding endpoint to return completed/incomplete sequencing requests

### DIFF
--- a/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
@@ -1,0 +1,83 @@
+package org.mskcc.limsrest.controller;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mskcc.limsrest.ConnectionLIMS;
+import org.mskcc.limsrest.service.GetSequencingRequestsTask;
+import org.mskcc.limsrest.service.RequestSummary;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.Long.parseLong;
+import static org.mskcc.limsrest.util.Utils.getResponseEntity;
+
+@RestController
+@RequestMapping("/")
+public class GetSequencingRequests {
+    private static Log log = LogFactory.getLog(GetSequencingRequests.class);
+    private final ConnectionLIMS conn;
+
+    public GetSequencingRequests(ConnectionLIMS conn) {
+        this.conn = conn;
+    }
+
+    /**
+     * Retrieves sequencing requests, which are requests that have a sample w/ a SeqAnalysisSampleQCModel DataRecord in
+     * their hierarchy
+     *  E.g.
+     *      { days: 7, complete: true }         Return completed requests from past week (failed doesn't matter)
+     *      { complete: false, failed: true }   Return incomplete requests INCLUDING those with failed samples
+     *      { complete: false, failed: false }  Return incomplete requests EXCLUDING those with failed samples
+     *
+     * @param days          Number of days from which to query for sequencingrequests
+     * @param complete      Whether to return completed sequencing requests
+     * @param includeFailed Whether to included samples w/ failed SeqAnalysisSampleQCModel records
+     * @param request
+     * @return
+     */
+    @GetMapping("/getSequencingRequests")
+    public ResponseEntity<Map<String, Object>> getContent(@RequestParam(value = "days", defaultValue = "7") String days,
+                                                          @RequestParam(value = "complete", defaultValue = "true") String complete,
+                                                          @RequestParam(value = "includeFailed", defaultValue = "false") String includeFailed,
+                                                          HttpServletRequest request) {
+        String.format("Starting /getSequencingRequests?days=%s&igoComplete=%s&includeFailed=%s client IP: %s",
+                days, complete, includeFailed, request.getRemoteAddr());
+
+        Map<String, Object> resp = new HashMap<>();
+
+        Long numDays = 0L;
+        try {
+            numDays = parseLong(days);
+        } catch (NumberFormatException e) {
+            String clientMessage = String.format("Couldn't process input days: %s", days);
+            log.error(String.format("%s. Error: %s", clientMessage, e.getMessage()));
+            resp.put("message", clientMessage);
+            resp.put("status", "Failed");
+            return getResponseEntity(resp, HttpStatus.BAD_REQUEST);
+        }
+
+        Boolean igoComplete = Boolean.parseBoolean(complete);
+        Boolean includeFailedRequests = Boolean.parseBoolean(includeFailed);
+        if (numDays < 0) {
+            String clientMessage = String.format("Requested days must be greater than 0. Received Days: %s", days);
+            resp.put("message", clientMessage);
+            resp.put("status", "Failed");
+            return getResponseEntity(resp, HttpStatus.BAD_REQUEST);
+        }
+
+        GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, igoComplete, includeFailedRequests);
+        List<RequestSummary> requests = task.execute(this.conn.getConnection());
+        resp.put("status", "Success");
+        resp.put("requests", requests);
+        return getResponseEntity(resp, HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
@@ -34,7 +34,7 @@ public class GetSequencingRequests {
      * Retrieves sequencing requests, which are requests that have a sample w/ a SeqAnalysisSampleQCModel DataRecord in
      * their hierarchy
      *      E.g.
-     *          { days: 14, complete: true }     Return completed requests from past two weeks
+     *          { days: 14, complete: true }    Return completed requests from past two weeks
      *          { complete: false }             Return incomplete requests (default: from past week)
      *
      * @param days          Number of days from which to query for sequencingrequests

--- a/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
@@ -33,14 +33,12 @@ public class GetSequencingRequests {
     /**
      * Retrieves sequencing requests, which are requests that have a sample w/ a SeqAnalysisSampleQCModel DataRecord in
      * their hierarchy
-     *  E.g.
-     *      { days: 7, complete: true }         Return completed requests from past week (failed doesn't matter)
-     *      { complete: false, failed: true }   Return incomplete requests INCLUDING those with failed samples
-     *      { complete: false, failed: false }  Return incomplete requests EXCLUDING those with failed samples
+     *      E.g.
+     *          { days: 14, complete: true }     Return completed requests from past two weeks
+     *          { complete: false }             Return incomplete requests (default: from past week)
      *
      * @param days          Number of days from which to query for sequencingrequests
      * @param complete      Whether to return completed sequencing requests
-     * @param includeFailed Whether to included samples w/ failed SeqAnalysisSampleQCModel records
      * @param request
      * @return
      */

--- a/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
@@ -38,16 +38,16 @@ public class GetSequencingRequests {
      *          { complete: false }             Return incomplete requests (default: from past week)
      *
      * @param days          Number of days from which to query for sequencingrequests
-     * @param complete      Whether to return completed sequencing requests
+     * @param delivered     Whether to return delivered sequencing requests
      * @param request
      * @return
      */
     @GetMapping("/getSequencingRequests")
     public ResponseEntity<Map<String, Object>> getContent(@RequestParam(value = "days", defaultValue = "7") String days,
-                                                          @RequestParam(value = "complete", defaultValue = "true") String complete,
+                                                          @RequestParam(value = "delivered", defaultValue = "true") String delivered,
                                                           HttpServletRequest request) {
         String.format("Starting /getSequencingRequests?days=%s&igoComplete=%s client IP: %s",
-                days, complete, request.getRemoteAddr());
+                days, delivered, request.getRemoteAddr());
 
         Map<String, Object> resp = new HashMap<>();
 
@@ -62,7 +62,7 @@ public class GetSequencingRequests {
             return getResponseEntity(resp, HttpStatus.BAD_REQUEST);
         }
 
-        Boolean igoComplete = Boolean.parseBoolean(complete);
+        Boolean isDelivered = Boolean.parseBoolean(delivered);
         if (numDays < 0) {
             String clientMessage = String.format("Requested days must be greater than 0. Received Days: %s", days);
             resp.put("message", clientMessage);
@@ -70,7 +70,7 @@ public class GetSequencingRequests {
             return getResponseEntity(resp, HttpStatus.BAD_REQUEST);
         }
 
-        GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, igoComplete);
+        GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, isDelivered);
         List<RequestSummary> requests = task.execute(this.conn.getConnection());
         resp.put("status", "Success");
         resp.put("requests", requests);

--- a/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.lang.Long.parseLong;
+import static com.velox.api.datarecord.DataFieldHelper.parseInteger;
 import static org.mskcc.limsrest.util.Utils.getResponseEntity;
 
 @RestController
@@ -51,9 +51,9 @@ public class GetSequencingRequests {
 
         Map<String, Object> resp = new HashMap<>();
 
-        Long numDays = 0L;
+        Integer numDays = 0;
         try {
-            numDays = parseLong(days);
+            numDays = parseInteger(days);
         } catch (NumberFormatException e) {
             String clientMessage = String.format("Couldn't process input days: %s", days);
             log.error(String.format("%s. Error: %s", clientMessage, e.getMessage()));

--- a/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
@@ -47,10 +47,9 @@ public class GetSequencingRequests {
     @GetMapping("/getSequencingRequests")
     public ResponseEntity<Map<String, Object>> getContent(@RequestParam(value = "days", defaultValue = "7") String days,
                                                           @RequestParam(value = "complete", defaultValue = "true") String complete,
-                                                          @RequestParam(value = "includeFailed", defaultValue = "false") String includeFailed,
                                                           HttpServletRequest request) {
-        String.format("Starting /getSequencingRequests?days=%s&igoComplete=%s&includeFailed=%s client IP: %s",
-                days, complete, includeFailed, request.getRemoteAddr());
+        String.format("Starting /getSequencingRequests?days=%s&igoComplete=%s client IP: %s",
+                days, complete, request.getRemoteAddr());
 
         Map<String, Object> resp = new HashMap<>();
 
@@ -66,7 +65,6 @@ public class GetSequencingRequests {
         }
 
         Boolean igoComplete = Boolean.parseBoolean(complete);
-        Boolean includeFailedRequests = Boolean.parseBoolean(includeFailed);
         if (numDays < 0) {
             String clientMessage = String.format("Requested days must be greater than 0. Received Days: %s", days);
             resp.put("message", clientMessage);
@@ -74,7 +72,7 @@ public class GetSequencingRequests {
             return getResponseEntity(resp, HttpStatus.BAD_REQUEST);
         }
 
-        GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, igoComplete, includeFailedRequests);
+        GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, igoComplete);
         List<RequestSummary> requests = task.execute(this.conn.getConnection());
         resp.put("status", "Success");
         resp.put("requests", requests);

--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -25,12 +25,12 @@ import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
 public class GetSequencingRequestsTask extends LimsTask {
     private static Log log = LogFactory.getLog(GetIgoRequestsTask.class);
 
-    private Long days;                  // Number of days since sequencing
-    private Boolean igoComplete;        // Whether to determine requests that have been marked IGO-COMPLETE
+    private Long days;          // Number of days since sequencing
+    private Boolean delivered;  // Whether to determine requests that have been marked IGO-COMPLETE
 
-    public GetSequencingRequestsTask(Long days, Boolean igoComplete) {
+    public GetSequencingRequestsTask(Long days, Boolean delivered) {
         this.days = days;
-        this.igoComplete = igoComplete;
+        this.delivered = delivered;
     }
 
     @PreAuthorize("hasRole('READ')")
@@ -88,9 +88,9 @@ public class GetSequencingRequestsTask extends LimsTask {
             rs.setInvestigator(getRecordStringValue(request, RequestModel.INVESTIGATOR, user));
             rs.setPi(getRecordStringValue(request, RequestModel.LABORATORY_HEAD, user));
             rs.setRequestType(getRecordStringValue(request, RequestModel.REQUEST_NAME, user));
-            rs.setReceivedDate(getRecordLongValue(request, RequestModel.RECEIVED_DATE, user));
+            // rs.setReceivedDate(getRecordLongValue(request, RequestModel.RECEIVED_DATE, user));
             rs.setRecentDeliveryDate(getRecordLongValue(request, RequestModel.RECENT_DELIVERY_DATE, user));
-            rs.setCompletedDate(getRecordLongValue(request, RequestModel.COMPLETED_DATE, user));
+            // rs.setCompletedDate(getRecordLongValue(request, RequestModel.COMPLETED_DATE, user));
             rs.setIsIgoComplete(isIgoComplete(request, user));
             requests.add(rs);
         }
@@ -121,7 +121,7 @@ public class GetSequencingRequestsTask extends LimsTask {
      * @return Request Query
      */
     private String getRequestQuery(String requestId) {
-        if (this.igoComplete) {
+        if (this.delivered) {
             // If IGO-Complete, the recent-delivery date should not be null
             return String.format("%s = '%s' and %s IS NOT NULL", RequestModel.REQUEST_ID, requestId,
                     RequestModel.RECENT_DELIVERY_DATE);

--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -116,7 +116,7 @@ public class GetSequencingRequestsTask extends LimsTask {
     }
 
     /**
-     * Returns the query to use to retrieve the IGO requests based on @igoComplete
+     * Returns the query to use to retrieve the IGO requests based on @delivered
      *
      * @return Request Query
      */

--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -26,14 +26,12 @@ import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
 public class GetSequencingRequestsTask extends LimsTask {
     private static Log log = LogFactory.getLog(GetIgoRequestsTask.class);
 
-    private Long days;
-    private Boolean igoComplete;
-    private Boolean includeFailed;
+    private Long days;                  // Number of days since sequencing
+    private Boolean igoComplete;        // Whether to determine requests that have been marked IGO-COMPLETE
 
-    public GetSequencingRequestsTask(Long days, Boolean igoComplete, Boolean includeFailed) {
+    public GetSequencingRequestsTask(Long days, Boolean igoComplete) {
         this.days = days;
         this.igoComplete = igoComplete;
-        this.includeFailed = includeFailed;
     }
 
     @PreAuthorize("hasRole('READ')")

--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -1,0 +1,117 @@
+package org.mskcc.limsrest.service;
+
+import com.velox.api.datarecord.DataRecord;
+import com.velox.api.datarecord.IoError;
+import com.velox.api.datarecord.NotFound;
+import com.velox.api.user.User;
+import com.velox.api.util.ServerException;
+import com.velox.sapioutils.client.standalone.VeloxConnection;
+import com.velox.sloan.cmo.recmodels.RequestModel;
+import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.mskcc.limsrest.util.StatusTrackerConfig.isIgoComplete;
+import static org.mskcc.limsrest.util.Utils.getRecordLongValue;
+import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
+
+public class GetSequencingRequestsTask extends LimsTask {
+    private static Log log = LogFactory.getLog(GetIgoRequestsTask.class);
+
+    private Long days;
+    private Boolean igoComplete;
+
+    public GetSequencingRequestsTask(Long days, Boolean igoComplete) {
+        this.days = days;
+        this.igoComplete = igoComplete;
+    }
+
+    private long getSearchPoint() {
+        long now = System.currentTimeMillis();
+        long offset = days * 24 * 60 * 60 * 1000;
+        return now - offset;
+    }
+
+    /**
+     * Returns the query to use to retrieve the IGO request
+     * <p>
+     * NOTE - This should be in sync w/ @StatusTrackerConfig::isIgoComplete. If changing this, uncomment
+     *
+     * @return
+     * @getIgoRequestsTask_matchesIsIgoCompleteUtil_* tests in GetIgoRequestsTaskTest
+     */
+    private String getQuery() {
+        long searchPoint = getSearchPoint();
+        if (this.igoComplete) {
+            return String.format("%s > %d AND PassedQc = TRUE", SeqAnalysisSampleQCModel.DATE_CREATED, searchPoint);
+        }
+        return String.format("%s > %d AND PassedQc = FALSE", SeqAnalysisSampleQCModel.DATE_CREATED, searchPoint);
+    }
+
+    @PreAuthorize("hasRole('READ')")
+    @Override
+    public List<RequestSummary> execute(VeloxConnection conn) {
+        User user = conn.getUser();
+        String query = getQuery();
+        List<DataRecord> records = new ArrayList<>();
+        try {
+            records = conn.getDataRecordManager().queryDataRecords(SeqAnalysisSampleQCModel.DATA_TYPE_NAME, query, user);
+        } catch (IoError | RemoteException | NotFound e) {
+            log.error(String.format("Failed to query DataRecords w/ query: %s", query));
+            return new ArrayList<>();
+        }
+
+        List<List<DataRecord>> parentSamples = new ArrayList<>();
+        try {
+            parentSamples = dataRecordManager.getParentsOfType(records, "Sample", user);
+        } catch (ServerException | RemoteException e) {
+            log.error("Failed to query Samples");
+        }
+
+        List<String> reqIds = new LinkedList<>();
+        for (List<DataRecord> samples : parentSamples) {
+            for (DataRecord sample : samples) {
+                try {
+                    String possibleReqId = getRecordStringValue(sample, RequestModel.REQUEST_ID, user);
+                    if (!reqIds.contains(possibleReqId)) {
+                        log.info("Adding " + possibleReqId);
+                        reqIds.add(possibleReqId);
+                    }
+                } catch (NullPointerException npe) {
+                }
+            }
+        }
+        List<DataRecord> requestRecords = new LinkedList<>();
+        for (String rid : reqIds) {
+            try {
+                requestRecords.addAll(dataRecordManager.queryDataRecords(RequestModel.DATA_TYPE_NAME,
+                        "RequestId = '" + rid + "'", user));
+            } catch (RemoteException | NotFound | IoError e) {
+                log.error("Failed to query Samples");
+            }
+        }
+
+        List<RequestSummary> requests = new ArrayList<>();
+
+        for (DataRecord request : requestRecords) {
+            String requestId = getRecordStringValue(request, RequestModel.REQUEST_ID, user);
+            RequestSummary rs = new RequestSummary(requestId);
+            rs.setInvestigator(getRecordStringValue(request, RequestModel.INVESTIGATOR, user));
+            rs.setPi(getRecordStringValue(request, RequestModel.LABORATORY_HEAD, user));
+            rs.setRequestType(getRecordStringValue(request, RequestModel.REQUEST_NAME, user));
+            rs.setReceivedDate(getRecordLongValue(request, RequestModel.RECEIVED_DATE, user));
+            rs.setRecentDeliveryDate(getRecordLongValue(request, RequestModel.RECENT_DELIVERY_DATE, user));
+            rs.setCompletedDate(getRecordLongValue(request, RequestModel.COMPLETED_DATE, user));
+            rs.setIsIgoComplete(isIgoComplete(request, user));
+            requests.add(rs);
+        }
+
+        return requests;
+    }
+}

--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -25,10 +25,10 @@ import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
 public class GetSequencingRequestsTask extends LimsTask {
     private static Log log = LogFactory.getLog(GetIgoRequestsTask.class);
 
-    private Long days;          // Number of days since sequencing
+    private Integer days;       // Number of days since sequencing
     private Boolean delivered;  // Whether to determine requests that have been marked IGO-COMPLETE
 
-    public GetSequencingRequestsTask(Long days, Boolean delivered) {
+    public GetSequencingRequestsTask(Integer days, Boolean delivered) {
         this.days = days;
         this.delivered = delivered;
     }

--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -35,46 +35,6 @@ public class GetSequencingRequestsTask extends LimsTask {
         this.includeFailed = includeFailed;
     }
 
-    private long getSearchPoint() {
-        long now = System.currentTimeMillis();
-        long offset = days * 24 * 60 * 60 * 1000;
-        return now - offset;
-    }
-
-    /**
-     * Returns the query to use to retrieve the IGO request
-     * NOTE - This should be in sync w/ @StatusTrackerConfig::isIgoComplete. If modifying, uncomment and rerun tests
-     * @getIgoRequestsTask_matchesIsIgoCompleteUtil_* tests in GetIgoRequestsTaskTest
-     *
-     * @return
-     */
-    private String getSeqAnalysisSampleQcQuery() {
-        long searchPoint = getSearchPoint();
-        if (this.igoComplete) {
-            return String.format("%s > %d AND PassedQc = TRUE", SeqAnalysisSampleQCModel.DATE_CREATED, searchPoint);
-        }
-        if (this.includeFailed) {
-            return String.format("%s > %d AND PassedQc = FALSE", SeqAnalysisSampleQCModel.DATE_CREATED, searchPoint);
-        }
-        return String.format("%s > %d AND PassedQc = FALSE AND %s != \"Failed\"",
-                SeqAnalysisSampleQCModel.DATE_CREATED, searchPoint, SeqAnalysisSampleQCModel.SEQ_QCSTATUS);
-    }
-
-    /**
-     * Returns the query to use to retrieve the IGO requests based on @igoComplete
-     *
-     * @return Request Query
-     */
-    private String getRequestQuery(String requestId) {
-        if (this.igoComplete) {
-            // If IGO-Complete, the recent-delivery date should not be null
-            return String.format("%s = '%s' and %s IS NOT NULL", RequestModel.REQUEST_ID, requestId,
-                    RequestModel.RECENT_DELIVERY_DATE);
-        }
-        // If incomplete, then there should not be a recent delivery date
-        return String.format("%s = '%s' and %s IS NULL", RequestModel.REQUEST_ID, requestId, RequestModel.RECENT_DELIVERY_DATE);
-    }
-
     @PreAuthorize("hasRole('READ')")
     @Override
     public List<RequestSummary> execute(VeloxConnection conn) {
@@ -136,5 +96,45 @@ public class GetSequencingRequestsTask extends LimsTask {
         }
 
         return requests;
+    }
+
+    private long getSearchPoint() {
+        long now = System.currentTimeMillis();
+        long offset = days * 24 * 60 * 60 * 1000;
+        return now - offset;
+    }
+
+    /**
+     * Returns the query to use to retrieve the IGO request
+     * NOTE - This should be in sync w/ @StatusTrackerConfig::isIgoComplete. If modifying, uncomment and rerun tests
+     * @getIgoRequestsTask_matchesIsIgoCompleteUtil_* tests in GetIgoRequestsTaskTest
+     *
+     * @return
+     */
+    private String getSeqAnalysisSampleQcQuery() {
+        long searchPoint = getSearchPoint();
+        if (this.igoComplete) {
+            return String.format("%s > %d AND PassedQc = TRUE", SeqAnalysisSampleQCModel.DATE_CREATED, searchPoint);
+        }
+        if (this.includeFailed) {
+            return String.format("%s > %d AND PassedQc = FALSE", SeqAnalysisSampleQCModel.DATE_CREATED, searchPoint);
+        }
+        return String.format("%s > %d AND PassedQc = FALSE AND %s != \"Failed\"",
+                SeqAnalysisSampleQCModel.DATE_CREATED, searchPoint, SeqAnalysisSampleQCModel.SEQ_QCSTATUS);
+    }
+
+    /**
+     * Returns the query to use to retrieve the IGO requests based on @igoComplete
+     *
+     * @return Request Query
+     */
+    private String getRequestQuery(String requestId) {
+        if (this.igoComplete) {
+            // If IGO-Complete, the recent-delivery date should not be null
+            return String.format("%s = '%s' and %s IS NOT NULL", RequestModel.REQUEST_ID, requestId,
+                    RequestModel.RECENT_DELIVERY_DATE);
+        }
+        // If incomplete, then there should not be a recent delivery date
+        return String.format("%s = '%s' and %s IS NULL", RequestModel.REQUEST_ID, requestId, RequestModel.RECENT_DELIVERY_DATE);
     }
 }

--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -9,7 +9,6 @@ import com.velox.api.util.ServerException;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
 import com.velox.sloan.cmo.recmodels.FlowCellLaneModel;
 import com.velox.sloan.cmo.recmodels.RequestModel;
-import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -65,7 +64,8 @@ public class GetSequencingRequestsTask extends LimsTask {
                         log.info(String.format("Adding RequestID: %s", possibleReqId));
                         reqIds.add(possibleReqId);
                     }
-                } catch (NullPointerException e) {}
+                } catch (NullPointerException e) {
+                }
             }
         }
         List<DataRecord> requestRecords = new LinkedList<>();
@@ -105,11 +105,10 @@ public class GetSequencingRequestsTask extends LimsTask {
     }
 
     /**
-     * Returns the query to use to retrieve the IGO request
-     * NOTE - This should be in sync w/ @StatusTrackerConfig::isIgoComplete. If modifying, uncomment and rerun tests
-     * @getIgoRequestsTask_matchesIsIgoCompleteUtil_* tests in GetIgoRequestsTaskTest
+     * Returns the query to use to retrieve the samples that have been sequenced, which should all have a FlowCellLane
+     * child record
      *
-     * @return
+     * @return Query for FlowCellLaneModel
      */
     private String getFlowCellLaneQuery() {
         long searchPoint = getSearchPoint();

--- a/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
+++ b/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
@@ -119,7 +119,7 @@ public class StatusTrackerConfig {
      *      Extraction Requests - 1) Status: "Completed", 2) Non-null Completed Date
      *      Other - Non-null Recent Delivery Date
      *
-     * NOTE - This should be in sync w/ @StatusTrackerConfig::isIgoComplete. If changing this, uncomment
+     * NOTE - This should be in sync w/ @ToggleSampleQcStatus::setSeqAnalysisSampleQcStatus. If changing this, uncomment
      * @getIgoRequestsTask_matchesIsIgoCompleteUtil_* tests in GetIgoRequestsTaskTest
      * @param record
      * @param user

--- a/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
@@ -1,32 +1,35 @@
 package org.mskcc.limsrest.service;
 
+import com.velox.api.datarecord.DataRecord;
 import com.velox.api.datarecord.DataRecordManager;
 import com.velox.api.user.User;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
+import com.velox.sloan.cmo.recmodels.FlowCellLaneModel;
+import com.velox.sloan.cmo.recmodels.RequestModel;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import javax.validation.constraints.AssertTrue;
+import javax.xml.crypto.Data;
 import java.util.ArrayList;
+import java.util.Arrays;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyList;
 import static org.mockito.Mockito.when;
 
 public class GetSequencingRequestsTaskTest {
-
-    @Before
-    public void setup() {
-    }
-
-    @After
-    public void tearDown() {
-    }
-
     @Test
-    public void isIMPACTOrHEMEPACT() {
-        GetSequencingRequestsTask task = new GetSequencingRequestsTask(0L, Boolean.TRUE, Boolean.TRUE);
+    public void queriesRequestsWithFlowCellSamples() {
+        Long numDays = 7L;
+        Boolean igoComplete = Boolean.TRUE;
+
+        GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, igoComplete);
         VeloxConnection conn = Mockito.mock(VeloxConnection.class);
         User user = Mockito.mock(User.class);
+        DataRecord sample = Mockito.mock(DataRecord.class);
         DataRecordManager dataRecordManager = Mockito.spy(DataRecordManager.class);
         Mockito.doReturn(user).when(conn).getUser();
         Mockito.doReturn(dataRecordManager).when(conn).getDataRecordManager();
@@ -35,20 +38,33 @@ public class GetSequencingRequestsTaskTest {
             when(dataRecordManager.queryDataRecords(
                     Mockito.anyString(),
                     Mockito.anyString(),
-                    user
+                    Mockito.any(User.class)
             )).thenReturn(new ArrayList<>());
+
+            when(dataRecordManager.getParentsOfType(
+                    Mockito.anyListOf(DataRecord.class),
+                    Mockito.anyString(),
+                    Mockito.any(User.class)
+            )).thenReturn(Arrays.asList(Arrays.asList(sample)));
+
+            when(sample.getStringVal(
+                    Mockito.anyString(),
+                    Mockito.any(User.class)
+            )).thenReturn("TEST_REQUEST");
         } catch (Exception e) {
+            assertTrue(String.format("Failed to mock: %s", e.getMessage()), false);
         }
 
         task.execute(conn);
 
         try {
-            Mockito.verify(dataRecordManager, Mockito.times(5)).queryDataRecords(
+            Mockito.verify(dataRecordManager, Mockito.times(2)).queryDataRecords(
                     Mockito.anyString(),
                     Mockito.anyString(),
-                    user
+                    Mockito.any(User.class)
             );
         } catch (Exception e) {
+            assertTrue(String.format("Mockito verify failed: %s", e.getMessage()), false);
         }
     }
 }

--- a/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
@@ -4,20 +4,13 @@ import com.velox.api.datarecord.DataRecord;
 import com.velox.api.datarecord.DataRecordManager;
 import com.velox.api.user.User;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
-import com.velox.sloan.cmo.recmodels.FlowCellLaneModel;
-import com.velox.sloan.cmo.recmodels.RequestModel;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import javax.validation.constraints.AssertTrue;
-import javax.xml.crypto.Data;
 import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyList;
 import static org.mockito.Mockito.when;
 
 public class GetSequencingRequestsTaskTest {

--- a/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
@@ -17,9 +17,9 @@ public class GetSequencingRequestsTaskTest {
     @Test
     public void queriesRequestsWithFlowCellSamples() {
         Long numDays = 7L;
-        Boolean igoComplete = Boolean.TRUE;
+        Boolean delivered = Boolean.TRUE;
 
-        GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, igoComplete);
+        GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, delivered);
         VeloxConnection conn = Mockito.mock(VeloxConnection.class);
         User user = Mockito.mock(User.class);
         DataRecord sample = Mockito.mock(DataRecord.class);

--- a/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
@@ -1,19 +1,27 @@
 package org.mskcc.limsrest.service;
 
-import com.velox.api.datarecord.DataRecord;
 import com.velox.api.datarecord.DataRecordManager;
 import com.velox.api.user.User;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 public class GetSequencingRequestsTaskTest {
+
+    @Before
+    public void setup() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
     @Test
     public void isIMPACTOrHEMEPACT() {
         GetSequencingRequestsTask task = new GetSequencingRequestsTask(0L, Boolean.TRUE, Boolean.TRUE);
@@ -29,7 +37,8 @@ public class GetSequencingRequestsTaskTest {
                     Mockito.anyString(),
                     user
             )).thenReturn(new ArrayList<>());
-        } catch (Exception e) {}
+        } catch (Exception e) {
+        }
 
         task.execute(conn);
 
@@ -39,6 +48,7 @@ public class GetSequencingRequestsTaskTest {
                     Mockito.anyString(),
                     user
             );
-        } catch (Exception e) {}
+        } catch (Exception e) {
+        }
     }
 }

--- a/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
@@ -1,0 +1,44 @@
+package org.mskcc.limsrest.service;
+
+import com.velox.api.datarecord.DataRecord;
+import com.velox.api.datarecord.DataRecordManager;
+import com.velox.api.user.User;
+import com.velox.sapioutils.client.standalone.VeloxConnection;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class GetSequencingRequestsTaskTest {
+    @Test
+    public void isIMPACTOrHEMEPACT() {
+        GetSequencingRequestsTask task = new GetSequencingRequestsTask(0L, Boolean.TRUE, Boolean.TRUE);
+        VeloxConnection conn = Mockito.mock(VeloxConnection.class);
+        User user = Mockito.mock(User.class);
+        DataRecordManager dataRecordManager = Mockito.spy(DataRecordManager.class);
+        Mockito.doReturn(user).when(conn).getUser();
+        Mockito.doReturn(dataRecordManager).when(conn).getDataRecordManager();
+
+        try {
+            when(dataRecordManager.queryDataRecords(
+                    Mockito.anyString(),
+                    Mockito.anyString(),
+                    user
+            )).thenReturn(new ArrayList<>());
+        } catch (Exception e) {}
+
+        task.execute(conn);
+
+        try {
+            Mockito.verify(dataRecordManager, Mockito.times(5)).queryDataRecords(
+                    Mockito.anyString(),
+                    Mockito.anyString(),
+                    user
+            );
+        } catch (Exception e) {}
+    }
+}

--- a/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 public class GetSequencingRequestsTaskTest {
     @Test
     public void queriesRequestsWithFlowCellSamples() {
-        Long numDays = 7L;
+        Integer numDays = 7;
         Boolean delivered = Boolean.TRUE;
 
         GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, delivered);


### PR DESCRIPTION
**Change**: Adding endpoint to return all sequencing requests, a "catch-all" to return all requests that need to be reviewed

Returns Sequencing Requests that have either been marked IGO-Complete or not. This is important because request that have not been marked IGO-Complete are still pending some action before they can be delivered, however, if they have been marked passed or failed their initial demux, then they will not appear on the run-qc site

_Implementation_
1. Get all FlowCellLane records created in past n days
2. Get all samples for those records
3. Get all unique Requests from those samples that are IGO-Complete or not