### PR TITLE
Fixing case of descendant SeqAnalysisSampleQCModel DataRecords

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSampleTree.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSampleTree.java
@@ -180,6 +180,7 @@ public class ProjectSampleTree {
         }
 
         for (DataRecord sampleQcRecord : sampleQcRecords) {
+            // Check to see if one of the @sampleQcRecords has already marked the ProjectSample as IGO-Complete
             if (!isQcIgoComplete()) {
                 Boolean isIgoComplete = isQcStatusIgoComplete(sampleQcRecord, this.user);
                 if (isIgoComplete) {


### PR DESCRIPTION
**Change**: Check all SeqAnalysisSampleQCModel descendants from input Sample DataRecord instead of just the first SeqAnalysisSampleQCModel child

A Sample DataRecord can have a SeqAnalysisSampleQCModel child AND have children Sample DataRecords that also have SeqAnalysisSampleQCModel children. Therefore, we need to grab all descendant SeqAnalysisSampleQCModel from the input Sample DataRecord, @record, and check to see if any of them have been marked as IGO-Complete. This is because as long as one child has successfully completed the sequencing workflow, this WorkflowSample should be marked as Complete and NOT failed