### PR TITLE
Adding PendingStage

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -131,8 +131,14 @@ public class GetRequestTrackingTask {
         Integer numTotal = 0;
         StageTracker stage;
         Integer numComplete = 0;
+        String pendingStageName = STAGE_COMPLETE;
+        String stageName;
         for (Map.Entry<String, StageTracker> requestStage : stages.entrySet()) {
+            stageName = requestStage.getKey();
             stage = requestStage.getValue();
+            if(pendingStageName.equals(STAGE_COMPLETE) && !stage.getComplete()){
+                pendingStageName = stageName;
+            }
             isStagesComplete = isStagesComplete && stage.getComplete();
             numFailed += stage.getFailedSamplesCount();
             numTotal = stage.getSize() > numTotal ? stage.getSize() : numTotal;
@@ -143,6 +149,7 @@ public class GetRequestTrackingTask {
         projectStatus.put("completed", numComplete);
         projectStatus.put("total", numTotal);
         projectStatus.put("failed", numFailed);
+        projectStatus.put("pendingStage", pendingStageName);
 
         return projectStatus;
     }

--- a/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
+++ b/src/main/java/org/mskcc/limsrest/util/StatusTrackerConfig.java
@@ -50,7 +50,8 @@ public class StatusTrackerConfig {
     public static final String STAGE_PATHOLOGY = "Pathology";
     public static final String STAGE_Digital_PCR = "Digital PCR";
     public static final String STAGE_RETURNED_TO_USER = "Returned to User";
-    public static final String STAGE_AWAITING_PROCESSING = "Awaiting Processing"; // Use for undetermined, e.g. manual status assignment/new workflow
+    public static final String STAGE_AWAITING_PROCESSING = "Awaiting Processing";   // Use for undetermined, e.g. manual status assignment/new workflow
+    public static final String STAGE_COMPLETE = "Completed";                        // Used to indicate no pending stage
     // TODO - This should be added, but in a way that it disappears once it is not longer processing
     // TODO - PROCESSING STAGES: "Ready for Processing", "Awaiting Processing", "In Processing", & "Processing Completed"
 


### PR DESCRIPTION
**Change**
Add `pendingStage` to `summary` of `getRequestTracking` API response

_More_
PendingStage is reported as first stage in a request that has not completed - conservative
e.g. 7/8 finished sequencing and 7/7 finished data qc -> `pendingStage: "Sequencing"`

**Testing (local)**
See `getRequestTrackingTaskTest.java`

**Testing (tango)**
```
{
   "summary": {
      "total": 10,
      "RecentDeliveryDate": null,
      "stagesComplete": false,
      "pendingStage": "Sequencing",
      "isIgoComplete": false,
      "completed": 0,
      "failed": 0,
      "CompletedDate": null
   },
   "metaData": {},
   "requestId": "10793",
   "stages": [],
   "samples": []
}
```
https://tango.mskcc.org:8443/LimsRest/getRequestTracking?request=10793
