### PR TITLE
Mark cmorequests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ nexusUrlReleases=http://bale:8081/service/local/repositories/releases/content
 nexusUrlSnapshots=http://bale:8081/service/local/repositories/snapshots/content
 nexusUsername=admin
 nexusPassword=
-target=local
+target=

--- a/src/main/java/org/mskcc/limsrest/service/GetSampleMetadataTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSampleMetadataTask.java
@@ -4,6 +4,7 @@ import com.velox.api.datarecord.DataRecord;
 import com.velox.api.datarecord.DataRecordManager;
 import com.velox.api.user.User;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
+import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -82,7 +83,8 @@ public class GetSampleMetadataTask {
                         String sampleOrigin = (String) getFieldValueForSample(sample, cmoInfoRec, "SampleOrigin", "SampleOrigin", "String");
                         String tissueSource = (String) getFieldValueForSample(sample, cmoInfoRec, "TissueSource", "TissueSource", "String");
                         String tissueLocation = (String) getFieldValueForSample(sample, cmoInfoRec, "TissueLocation", "TissueLocation", "String");
-                        String baitset = getBaitSet(sample, user);;
+                        List<DataRecord> seqQcRecords = getChildDataRecordsOfType(sample, SeqAnalysisSampleQCModel.DATA_TYPE_NAME, user);
+                        String baitset = getBaitSet(sample, seqQcRecords, user);
                         log.info("baitset: " + baitset);
                         String fastqPath = "";
                         String ancestorSample = getOriginSampleId(sample, user);

--- a/src/main/java/org/mskcc/limsrest/service/GetSampleStatusTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSampleStatusTask.java
@@ -4,6 +4,7 @@ import com.velox.api.datarecord.DataRecord;
 import com.velox.api.datarecord.DataRecordManager;
 import com.velox.api.user.User;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
+import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mskcc.limsrest.ConnectionLIMS;

--- a/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
@@ -9,6 +9,7 @@ import com.velox.api.user.User;
 import com.velox.api.util.ServerException;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
 import com.velox.sloan.cmo.recmodels.RequestModel;
+import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONException;
@@ -75,8 +76,9 @@ public class GetWESSampleDataTask {
             log.info(" Starting GetWesSample task using timestamp " + timestamp);
             List<DataRecord> dmpTrackerRecords = new ArrayList<>();
             try {
-                dmpTrackerRecords = dataRecordManager.queryDataRecords("DMPSampleTracker", "i_SampleTypeTumororNormal='Tumor' AND DateCreated > " + Long.parseLong(timestamp) + " AND i_SampleDownstreamApplication LIKE '%Exome%' COLLATE utf8_general_ci", user);
+//                dmpTrackerRecords = dataRecordManager.queryDataRecords("DMPSampleTracker", "i_SampleTypeTumororNormal='Tumor' AND DateCreated > " + Long.parseLong(timestamp) + " AND i_SampleDownstreamApplication LIKE '%Exome%' COLLATE utf8_general_ci", user);
 //                dmpTrackerRecords = dataRecordManager.queryDataRecords("DMPSampleTracker", "i_SampleTypeTumororNormal='Tumor' AND DateCreated > " + Long.parseLong(timestamp) + " AND i_SampleDownstreamApplication LIKE '%Exome%' AND i_StudySampleIdentifierInvesti LIKE 'P-0002976-T01-WES%' COLLATE utf8_general_ci", user);
+                dmpTrackerRecords = dataRecordManager.queryDataRecords("DMPSampleTracker", "i_StudySampleIdentifierInvesti IN ('P-0013536-T02-WES','P-0025596-T01-WES','P-0028625-T01-WES') AND i_SampleTypeTumororNormal='Tumor'" + " AND i_SampleDownstreamApplication LIKE '%Exome%' COLLATE utf8_general_ci", user);
                 log.info("Num dmpTracker Records: " + dmpTrackerRecords.size());
             } catch (Throwable e) {
                 log.error(e.getMessage(), e);
@@ -140,7 +142,8 @@ public class GetWESSampleDataTask {
                                         Boolean consentPartCStatus = getConsentStatus(consentCList, dmpPatientId);
                                         String sampleStatus = getMostAdvancedLimsStage(sample, igoRequestId, conn);
                                         log.info("sample status: " + sampleStatus);
-                                        String baitsetUsed = getBaitSet(sample, user);
+                                        List<DataRecord> seqQcRecords = getChildDataRecordsOfType(sample, SeqAnalysisSampleQCModel.DATA_TYPE_NAME, user);
+                                        String baitsetUsed = getBaitSet(sample, seqQcRecords, user);
                                         log.info("baitset: " + baitsetUsed);
                                         String accessLevel = "";
                                         String sequencingSite = "";

--- a/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
@@ -9,6 +9,7 @@ import com.velox.api.user.User;
 import com.velox.api.util.ServerException;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
 import com.velox.sloan.cmo.recmodels.RequestModel;
+import com.velox.sloan.cmo.recmodels.SampleCMOInfoRecordsModel;
 import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -95,8 +96,11 @@ public class GetWESSampleDataTask {
                     }
                     if (sampleCmoInfoRecs.size() > 0) {
                         for (DataRecord cmoInfoRec : sampleCmoInfoRecs) {
-                            DataRecord parentSamp = cmoInfoRec.getParentsOfType("Sample", user).get(0);
-                            List<DataRecord> allSamplesSharingCmoInfoRec = getChildSamplesWithRequestAsParent(parentSamp);
+                            List<DataRecord> parentSamps = cmoInfoRec.getParentsOfType("Sample", user);
+                            if (parentSamps.isEmpty()){
+                                log.info(String.format("%s record with recordid %d not linked to any parent Sample.", SampleCMOInfoRecordsModel.DATA_TYPE_NAME, cmoInfoRec.getRecordId()));
+                            }
+                            List<DataRecord> allSamplesSharingCmoInfoRec = !parentSamps.isEmpty() ? getChildSamplesWithRequestAsParent(parentSamps.get(0)): new ArrayList<>();
                             log.info("Total Wes Samples for shared CmoInfo Rec: " + allSamplesSharingCmoInfoRec.size());
                             if (allSamplesSharingCmoInfoRec.size()>0){
                                 for (DataRecord sample: allSamplesSharingCmoInfoRec){

--- a/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
@@ -76,9 +76,9 @@ public class GetWESSampleDataTask {
             log.info(" Starting GetWesSample task using timestamp " + timestamp);
             List<DataRecord> dmpTrackerRecords = new ArrayList<>();
             try {
-//                dmpTrackerRecords = dataRecordManager.queryDataRecords("DMPSampleTracker", "i_SampleTypeTumororNormal='Tumor' AND DateCreated > " + Long.parseLong(timestamp) + " AND i_SampleDownstreamApplication LIKE '%Exome%' COLLATE utf8_general_ci", user);
+                dmpTrackerRecords = dataRecordManager.queryDataRecords("DMPSampleTracker", "i_SampleTypeTumororNormal='Tumor' AND DateCreated > " + Long.parseLong(timestamp) + " AND i_SampleDownstreamApplication LIKE '%Exome%' COLLATE utf8_general_ci", user);
 //                dmpTrackerRecords = dataRecordManager.queryDataRecords("DMPSampleTracker", "i_SampleTypeTumororNormal='Tumor' AND DateCreated > " + Long.parseLong(timestamp) + " AND i_SampleDownstreamApplication LIKE '%Exome%' AND i_StudySampleIdentifierInvesti LIKE 'P-0002976-T01-WES%' COLLATE utf8_general_ci", user);
-                dmpTrackerRecords = dataRecordManager.queryDataRecords("DMPSampleTracker", "i_StudySampleIdentifierInvesti IN ('P-0013536-T02-WES','P-0025596-T01-WES','P-0028625-T01-WES') AND i_SampleTypeTumororNormal='Tumor'" + " AND i_SampleDownstreamApplication LIKE '%Exome%' COLLATE utf8_general_ci", user);
+                //dmpTrackerRecords = dataRecordManager.queryDataRecords("DMPSampleTracker", "i_StudySampleIdentifierInvesti IN ('P-0013536-T02-WES','P-0025596-T01-WES','P-0028625-T01-WES') AND i_SampleTypeTumororNormal='Tumor'" + " AND i_SampleDownstreamApplication LIKE '%Exome%' COLLATE utf8_general_ci", user);
                 log.info("Num dmpTracker Records: " + dmpTrackerRecords.size());
             } catch (Throwable e) {
                 log.error(e.getMessage(), e);

--- a/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
@@ -9,6 +9,7 @@ import com.velox.api.user.User;
 import com.velox.api.util.ServerException;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
 import com.velox.sloan.cmo.recmodels.RequestModel;
+import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.tomcat.util.ExceptionUtils;

--- a/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
@@ -88,6 +88,7 @@ public class GetWESSampleDataTask {
             JSONObject consentAList = getConsentStatusDataValues("parta");
             JSONObject consentCList = getConsentStatusDataValues("partc");
             if (!dmpTrackerRecords.isEmpty()) {
+                int totalProcessed = 0;
                 for (DataRecord dmpTrackRec : dmpTrackerRecords) {
                     List<DataRecord> sampleCmoInfoRecs = new ArrayList<>();
                     if (dmpTrackRec.getValue("i_StudySampleIdentifierInvesti", user) != null) {
@@ -179,6 +180,8 @@ public class GetWESSampleDataTask {
                         WESSampleData nonIgoTrackingRecord = createNonIgoTrackingRecord(dmpTrackRec, consentAList, consentCList);
                         resultList.add(nonIgoTrackingRecord);
                     }
+                    totalProcessed ++;
+                    log.info("Total DMPTracker records processed: " + totalProcessed);
                 }
             }
             log.info("Results found: " + resultList.size() + " Elapsed time (ms): " + (System.currentTimeMillis() - start));

--- a/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetWESSampleDataTask.java
@@ -9,14 +9,11 @@ import com.velox.api.user.User;
 import com.velox.api.util.ServerException;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
 import com.velox.sloan.cmo.recmodels.RequestModel;
-import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.tomcat.util.ExceptionUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.mskcc.limsrest.ConnectionLIMS;
-import org.mskcc.limsrest.service.requesttracker.Request;
 import org.mskcc.limsrest.service.sampletracker.WESSampleData;
 
 import javax.net.ssl.*;
@@ -34,7 +31,6 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 
 import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
-import static org.apache.tomcat.util.ExceptionUtils.*;
 import static org.mskcc.limsrest.util.Utils.*;
 
 /**

--- a/src/main/java/org/mskcc/limsrest/util/Utils.java
+++ b/src/main/java/org/mskcc/limsrest/util/Utils.java
@@ -149,18 +149,18 @@ public class Utils {
      * Method to get BaitSet used for a sample.
      *
      * @param sample
+     * @param qcRecords
      * @return
      */
-    public static String getBaitSet(DataRecord sample, User user) {
+    public static String getBaitSet(DataRecord sample, List<DataRecord> qcRecords, User user) {
         try {
-            List<DataRecord> qcRecords = getChildDataRecordsOfType(sample, SeqAnalysisSampleQCModel.DATA_TYPE_NAME, user);
             if (qcRecords.isEmpty()) {
                 LOGGER.info(String.format("Seq qc record not found for sample with recordId: %d.", sample.getRecordId()));
                 return "";
             }
             for (DataRecord qcRec : qcRecords){
                 Object baitset = qcRec.getValue(SeqAnalysisSampleQCModel.BAIT_SET, user);
-                if (baitset != null){
+                if (baitset != null && !StringUtils.isBlank(baitset.toString())){
                     return baitset.toString();
                 }
             }
@@ -229,7 +229,7 @@ public class Utils {
      * @param user
      * @return
      */
-    private static List<DataRecord> getChildDataRecordsOfType(DataRecord sample, String childRecordType, User user){
+    public static List<DataRecord> getChildDataRecordsOfType(DataRecord sample, String childRecordType, User user){
         List<DataRecord> records = new ArrayList<>();
         try {
             Object requestId = sample.getValue(SampleModel.REQUEST_ID, user);

--- a/src/main/java/org/mskcc/limsrest/util/Utils.java
+++ b/src/main/java/org/mskcc/limsrest/util/Utils.java
@@ -112,7 +112,9 @@ public class Utils {
                     return true;
                 }
             }
-            // check if the status is actually failed but igoComplete is not marked true.
+            // check if the status is actually failed but igoComplete is not marked true. Sometimes, sample is marked failed
+            // but igoComplete is not checked. It is possible that we do not mark IgoComplete because there is not data to
+            // deliver to the user.
             for (DataRecord rec: qcRecords){
                 Object qcStatus = rec.getValue(SeqAnalysisSampleQCModel.SEQ_QCSTATUS, user);
                 if (qcStatus!= null && qcStatus.toString().equalsIgnoreCase(SEQ_QC_STATUS_FAILED)){


### PR DESCRIPTION
Changed logic to get baitsets from Samples when a Sample has more than one SeqAnalysisSampleQC records. Old logic looked at the first SeqAnalysisSampleQC record it found related to Sample. In some cases, the baitset info is not present on SeqAnalysisSampleQC records that fail Data QC. Eg: SeqAnalysisSampleQC records for "P-0035723-T01-WES", "P-0035103-T01-WES".