### PR TITLE
SearchPoint calculation: Integer -> Long

### DIFF
--- a/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.velox.api.datarecord.DataFieldHelper.parseInteger;
+import static com.velox.api.datarecord.DataFieldHelper.parseLong;
 import static org.mskcc.limsrest.util.Utils.getResponseEntity;
 
 @RestController
@@ -51,9 +51,9 @@ public class GetSequencingRequests {
 
         Map<String, Object> resp = new HashMap<>();
 
-        Integer numDays = 0;
+        Long numDays = 0L;
         try {
-            numDays = parseInteger(days);
+            numDays = parseLong(days);
         } catch (NumberFormatException e) {
             String clientMessage = String.format("Couldn't process input days: %s", days);
             log.error(String.format("%s. Error: %s", clientMessage, e.getMessage()));

--- a/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetSequencingRequests.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.velox.api.datarecord.DataFieldHelper.parseLong;
 import static org.mskcc.limsrest.util.Utils.getResponseEntity;
 
 @RestController
@@ -53,7 +52,7 @@ public class GetSequencingRequests {
 
         Long numDays = 0L;
         try {
-            numDays = parseLong(days);
+            numDays = Long.parseLong(days);
         } catch (NumberFormatException e) {
             String clientMessage = String.format("Couldn't process input days: %s", days);
             log.error(String.format("%s. Error: %s", clientMessage, e.getMessage()));

--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -25,10 +25,10 @@ import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
 public class GetSequencingRequestsTask extends LimsTask {
     private static Log log = LogFactory.getLog(GetIgoRequestsTask.class);
 
-    private Integer days;       // Number of days since sequencing
+    private Long days;          // Number of days since sequencing
     private Boolean delivered;  // Whether to determine requests that have been marked IGO-COMPLETE
 
-    public GetSequencingRequestsTask(Integer days, Boolean delivered) {
+    public GetSequencingRequestsTask(Long days, Boolean delivered) {
         this.days = days;
         this.delivered = delivered;
     }

--- a/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetSequencingRequestsTaskTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 public class GetSequencingRequestsTaskTest {
     @Test
     public void queriesRequestsWithFlowCellSamples() {
-        Integer numDays = 7;
+        Long numDays = 7L;
         Boolean delivered = Boolean.TRUE;
 
         GetSequencingRequestsTask task = new GetSequencingRequestsTask(numDays, delivered);


### PR DESCRIPTION
**Change:** `Integer numDays = 0;` -> `Long numDays = 0L;`

There's an Integer overflow when calculating the search point w/ `days * 24 * 60 * 60 * 1000`, e.g. `long searchpoitn = System.currentTimeMillis() - (numDays * 24 * 60 * 60 * 1000)`.
`numDays` needs to be changed to a Long

e.g. 
```
System.out.println(Integer.MAX_VALUE + 1);   // -2147483648
System.out.println(Integer.MAX_VALUE);   // 2147483647
```
so `{ANYTHING} minus {ANY_LARGE_INTEGER}` is yielding some incorrect results