### PR TITLE
Combining DataQcStage & Sequencing

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -9,10 +9,12 @@ import com.velox.sapioutils.client.standalone.VeloxConnection;
 import com.velox.sloan.cmo.recmodels.BankedSampleModel;
 import com.velox.sloan.cmo.recmodels.RequestModel;
 import com.velox.sloan.cmo.recmodels.SampleModel;
+import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.platform.commons.util.StringUtils;
 import org.mskcc.limsrest.ConnectionLIMS;
+import org.mskcc.limsrest.service.assignedprocess.QcStatus;
 import org.mskcc.limsrest.service.requesttracker.*;
 
 import java.rmi.RemoteException;
@@ -134,7 +136,7 @@ public class GetRequestTrackingTask {
         for (Map.Entry<String, StageTracker> requestStage : stages.entrySet()) {
             stageName = requestStage.getKey();
             stage = requestStage.getValue();
-            if(pendingStageName.equals(STAGE_COMPLETE) && !stage.getComplete()){
+            if (pendingStageName.equals(STAGE_COMPLETE) && !stage.getComplete()) {
                 pendingStageName = stageName;
             }
             isStagesComplete = isStagesComplete && stage.getComplete();
@@ -194,7 +196,7 @@ public class GetRequestTrackingTask {
      *          - All WorkflowSamples in a path to a Non-failed leaf sample should not be failed
      *          - If the root WorkflowSample has not failed, then the ProjectSample has not failed, i.e. there only
      *            needs to be one non-failed leaf sample in the tree for the whole tree to have not failed
-     *          - Note: A Failed WorkflowSample is complete (different from Stage)
+     *          - Note: A Failed WorkflowSample is complete - See @markFailedBranch
      *      III) COMPLETE: Sample has a Sample-DataType DataRecord  child           sample.complete = true
      *          - WorkflowSample w/ child is completed b/c moving on in the workflow creates a child sample
      *          - Non-failed WorkflowSample w/o sample children is incomplete
@@ -221,12 +223,10 @@ public class GetRequestTrackingTask {
     private ProjectSampleTree createWorkflowTree(WorkflowSample root, ProjectSampleTree tree) {
         tree.addStageToTracked(root);   // Update tree Project Sample stages w/ the input Workflow sample's stage
 
-        if (STAGE_DATA_QC.equals(root.getStage()) && !tree.isQcIgoComplete()) {
-            // The Data QC stage is updated by a node in Data QC stage. This node can update the entire tree's data
-            // QC status as a ProjectSample is marked Data QC complete if it has any one Data QC node marked passed
-            tree.updateDataQcStage(root);
+        if (hasFailedQcStage(root)) {
+            root.setFailed(Boolean.TRUE);
+            tree.markFailedBranch(root);
         }
-        // TODO - Add logic for when this is in the extraction stage
 
         // Search each child of the input
         DataRecord[] children = new DataRecord[0];
@@ -246,10 +246,14 @@ public class GetRequestTrackingTask {
             for (DataRecord record : children) {
                 if (isWorkflowSampleInProject(record, this.requestId, this.user)) {
                     WorkflowSample sample = new WorkflowSample(record, this.conn);
+
+                    // Children are related to the same Qc Records as their parents.
+                    sample.addSeqAnalysisQcRecords(root.getSeqAnalysisQcRecords());
+
                     sample.setParent(root);
                     if (STAGE_AWAITING_PROCESSING.equals(sample.getStage())) {
-                        // Update the stage of the sample to the parent stage if it is awaitingProcessing. If there is not
-                        // resolved parent, leave as "Awaiting Processing"
+                        // Update the stage of the sample to the parent stage if it is awaitingProcessing. If there is
+                        // not resolved parent, leave as "Awaiting Processing"
                         if (!STAGE_AWAITING_PROCESSING.equals(root.getStage())) {
                             sample.setStage(root.getStage());
                         }
@@ -273,6 +277,29 @@ public class GetRequestTrackingTask {
         }
         return tree;
     }
+
+    /**
+     * Returns status of whether the input WorkflowSample has failed seqAnalysisQcRecords
+     *
+     * @param node
+     */
+    private boolean hasFailedQcStage(WorkflowSample node) {
+        String nodeStage = node.getStage();
+        List<DataRecord> seqAnalysisQcRecords = node.getSeqAnalysisQcRecords();
+
+        if (seqAnalysisQcRecords.size() == 0 || !STAGE_SEQUENCING.equals(nodeStage)) {
+            // ONLY update projects with @STAGE_SEQUENCING WorkflowSamples that have a WorkflowSample in their path w/ a
+            // SeqAnalysisQcRecord child, which means that their sequencing results are going through QC
+            return false;
+        }
+
+        String qcStatus = getDataQcStatus(seqAnalysisQcRecords, this.user);
+        if (QcStatus.FAILED.toString().equals(qcStatus)) {
+            return true;
+        }
+        return false;
+    }
+
 
     /**
      * Returns whether the sample is part of the project based on whether the sampleId contains the requestId
@@ -301,6 +328,19 @@ public class GetRequestTrackingTask {
         WorkflowSample root = new WorkflowSample(record, this.conn);
         ProjectSampleTree rootTree = new ProjectSampleTree(root, user);
         rootTree.addSample(root);
+
+        // Evaluate overall QcStatus of ProjectSample from all descending SeqAnalysisSampleQC entries b/c the rule is
+        // simple - if there is an IGO-Complete SeqAnalysisSampleQC record, the projectSample is IgoComplete
+        try {
+            List<DataRecord> sampleQcRecords = record.getDescendantsOfType(SeqAnalysisSampleQCModel.DATA_TYPE_NAME, this.user);
+            if (sampleQcRecords.size() > 0) {
+                String qcStatus = getDataQcStatus(sampleQcRecords, this.user);
+                rootTree.setDataQcStatus(qcStatus);
+            }
+        } catch (RemoteException e) {
+            log.error(String.format("Unable to query descending SeqAnalysisSampleQC DataRecords from Sample DataRecord: %d",
+                    record.getRecordId()));
+        }
 
         // Recursively create the workflowTree from the input tree
         ProjectSampleTree workflowTree = createWorkflowTree(root, rootTree);

--- a/src/main/java/org/mskcc/limsrest/util/Utils.java
+++ b/src/main/java/org/mskcc/limsrest/util/Utils.java
@@ -16,6 +16,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mskcc.domain.sample.NucleicAcid;
 import org.mskcc.limsrest.ConnectionLIMS;
+import org.mskcc.limsrest.service.assignedprocess.QcStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -31,9 +32,6 @@ import java.util.regex.Pattern;
 import static org.mskcc.limsrest.util.StatusTrackerConfig.*;
 
 public class Utils {
-    public final static String SEQ_QC_STATUS_PASSED = "passed";
-    public final static String SEQ_QC_STATUS_FAILED = "failed";
-    public final static String SEQ_QC_STATUS_PENDING = "not available";
     private final static Log LOGGER = LogFactory.getLog(Utils.class);
     private final static List<String> TISSUE_SAMPLE_TYPES = Arrays.asList("cells", "plasma", "blood", "tissue", "buffy coat", "blocks/slides", "ffpe sample", "other", "tissue sample");
     private final static List<String> NUCLEIC_ACID_TYPES = Arrays.asList("dna", "rna", "cdna", "cfdna", "dna,cfdna", "amplicon", "pre-qc rna");
@@ -86,7 +84,7 @@ public class Utils {
         try{
             for (DataRecord rec: qcRecords){
                 Object qcStatus = rec.getValue(SeqAnalysisSampleQCModel.SEQ_QCSTATUS, user);
-                if (qcStatus!= null && qcStatus.toString().equalsIgnoreCase(SEQ_QC_STATUS_PASSED) && isQcStatusIgoComplete(rec, user)){
+                if (qcStatus != null && qcStatus.toString().equalsIgnoreCase(QcStatus.PASSED.toString()) && isQcStatusIgoComplete(rec, user)) {
                     return true;
                 }
             }
@@ -108,7 +106,7 @@ public class Utils {
         try{
             for (DataRecord rec: qcRecords){
                 Object qcStatus = rec.getValue(SeqAnalysisSampleQCModel.SEQ_QCSTATUS, user);
-                if (qcStatus!= null && qcStatus.toString().equalsIgnoreCase(SEQ_QC_STATUS_FAILED) && isQcStatusIgoComplete(rec, user)){
+                if (qcStatus != null && qcStatus.toString().equalsIgnoreCase(QcStatus.FAILED.toString()) && isQcStatusIgoComplete(rec, user)) {
                     return true;
                 }
             }
@@ -117,7 +115,7 @@ public class Utils {
             // deliver to the user.
             for (DataRecord rec: qcRecords){
                 Object qcStatus = rec.getValue(SeqAnalysisSampleQCModel.SEQ_QCSTATUS, user);
-                if (qcStatus!= null && qcStatus.toString().equalsIgnoreCase(SEQ_QC_STATUS_FAILED)){
+                if (qcStatus != null && qcStatus.toString().equalsIgnoreCase(QcStatus.FAILED.toString())) {
                     return true;
                 }
             }
@@ -143,7 +141,7 @@ public class Utils {
         DataRecord record = qcRecord[0];
         Boolean isComplete = isQcStatusIgoComplete(record, user);
         String sequencingStatus = getRecordStringValue(qcRecord[0], SeqAnalysisSampleQCModel.SEQ_QCSTATUS, user);
-        Boolean isFailed = sequencingStatus.equalsIgnoreCase(SEQ_QC_STATUS_FAILED);
+        Boolean isFailed = sequencingStatus.equalsIgnoreCase(QcStatus.FAILED.toString());
         return isComplete || isFailed;
     }
 

--- a/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
@@ -61,26 +61,23 @@ public class GetRequestTrackingTaskTest {
         List<Project> testCases = new ArrayList<>(Arrays.asList(
                 new ProjectBuilder("10795")
                         .addStage(STAGE_SUBMITTED, true, 3, 3, 0)
+                        .addStage(STAGE_AWAITING_PROCESSING, true, 3, 3, 0)
                         .addStage(STAGE_SEQUENCING, true, 3, 3, 0)
-                        .addStage(STAGE_DATA_QC, true, 3, 3, 0)
                         .build(),
                 new ProjectBuilder("09443_AS")
                         .addStage(STAGE_SUBMITTED, true, 8, 8, 0)
                         .addStage(STAGE_LIBRARY_PREP, true, 8, 8, 0)
                         .addStage(STAGE_SEQUENCING, true, 8, 8, 0)
-                        .addStage(STAGE_DATA_QC, true, 8, 8, 0)
                         .build(),
                 new ProjectBuilder("09602_F")
                         .addStage(STAGE_LIBRARY_PREP, true, 9, 9, 0)
                         .addStage(STAGE_LIBRARY_CAPTURE, true, 12, 12, 0)
                         .addStage(STAGE_SEQUENCING, true, 12, 12, 0)
-                        .addStage(STAGE_DATA_QC, true, 12, 12, 0)
                         .build(),
                 new ProjectBuilder("09367_K")
                         .addStage(STAGE_LIBRARY_PREP, true, 1, 1, 0)
                         .addStage(STAGE_LIBRARY_CAPTURE, true, 1, 1, 0)
                         .addStage(STAGE_SEQUENCING, true, 1, 1, 0)
-                        .addStage(STAGE_DATA_QC, true, 1, 1, 0)
                         .build()
         ));
 
@@ -102,7 +99,6 @@ public class GetRequestTrackingTaskTest {
                         .addStage(STAGE_LIBRARY_PREP, true, 4, 4, 0)
                         .addStage(STAGE_LIBRARY_QC, true, 4, 4, 0)
                         .addStage(STAGE_SEQUENCING, true, 4, 4, 0)
-                        .addStage(STAGE_DATA_QC, true, 4, 4, 0)
                         .build()
         ));
 
@@ -123,7 +119,6 @@ public class GetRequestTrackingTaskTest {
                 new ProjectBuilder("06302_AC")
                         .addStage(STAGE_LIBRARY_PREP, true, 56, 56, 0)
                         .addStage(STAGE_SEQUENCING, true, 56, 56, 0)
-                        .addStage(STAGE_DATA_QC, true, 56, 56, 0)
                         .build()
         ));
 
@@ -140,7 +135,6 @@ public class GetRequestTrackingTaskTest {
                         .addStage(STAGE_SUBMITTED, true, 10, 10, 0)
                         .addStage(STAGE_LIBRARY_PREP, true, 10, 10, 0)
                         .addStage(STAGE_SEQUENCING, false, 10, 0, 0)  // Passed, not complete
-                        .addStage(STAGE_DATA_QC, false, 10, 0, 0)
                         .addPendingStage(STAGE_SEQUENCING)
                         .build()));
 
@@ -149,24 +143,23 @@ public class GetRequestTrackingTaskTest {
 
     @Test
     public void failedComplete() throws Exception {
-        /*  Failed/Complete
+        /*  Failed/Complete10
             "06302_W",		// Good: 1 Failed Library Prep, 41 IGO-Complete
             "06302_AG",		// Not detecting the Data-QC failures
          */
         List<Project> testCases = new ArrayList<>(Arrays.asList(
                 new ProjectBuilder("06302_W")
                         .addStage(STAGE_LIBRARY_PREP, true, 42, 41, 1)
+                        .addStage(STAGE_LIBRARY_CAPTURE, true, 41, 41, 0)
                         .addStage(STAGE_LIBRARY_QC, true, 41, 41, 0)
                         .addStage(STAGE_SEQUENCING, true, 41, 41, 0)
-                        .addStage(STAGE_DATA_QC, true, 41, 41, 0)
                         .build(),
                 new ProjectBuilder("06302_AG")
                         .addStage(STAGE_LIBRARY_PREP, true, 382, 382, 0)
                         .addStage(STAGE_PENDING_USER_DECISION, true, 2, 0, 2)
+                        .addStage(STAGE_LIBRARY_CAPTURE, true, 380, 380, 0)
                         // TODO - Failed should be 48 & completed 332, but sequencing failures are difficult
-                        .addStage(STAGE_SEQUENCING, false, 380, 332, 0)
-                        .addStage(STAGE_DATA_QC, false, 380, 332, 48)
-                        .addPendingStage(STAGE_SEQUENCING)
+                        .addStage(STAGE_SEQUENCING, true, 380, 332, 48)
                         .build()
         ));
 
@@ -184,7 +177,6 @@ public class GetRequestTrackingTaskTest {
                         .addStage(STAGE_LIBRARY_PREP, true, 8, 8, 0)
                         .addStage(STAGE_LIBRARY_CAPTURE, true, 8, 8, 0)
                         .addStage(STAGE_SEQUENCING, false, 8, 0, 0)
-                        .addStage(STAGE_DATA_QC, false, 5, 0, 0)
                         .addPendingStage(STAGE_SEQUENCING)
                         .build()));
 
@@ -203,7 +195,6 @@ public class GetRequestTrackingTaskTest {
                         .addStage(STAGE_LIBRARY_PREP, false, 16, 16, 0)
                         .addStage(STAGE_LIBRARY_CAPTURE, false, 16, 16, 0)
                         .addStage(STAGE_SEQUENCING, false, 16, 16, 0)
-                        .addStage(STAGE_DATA_QC, false, 16, 16, 0)
                         .addPendingStage(STAGE_AWAITING_PROCESSING)
                         .build()));
 


### PR DESCRIPTION
Removing DataQcStage by combining it with the sequencing stage b/c:
 - DataQcStage and Sequencing stage both "complete" at the same time because sequencing completion is dependent on DataQcStage completion
 - DataQc records from SeqAnalysisSampleQC DataType can be descended from Workflow samples completely unrelated to Sequencing, e.g. LibraryPrep, which throws off the duration time for this stage (e.g. the "DataQcStage" start time will be that of the "LibraryPrep" start time, which makes the overall request duration (by adding up all the stages) much longer than it should be


ALSO:
 - Reordered PENDING_USE_DECISION to follow STAGE_LIBRARY_PREP and come before STAGE_LIBRARY_CAPTURE