### PR TITLE
Fixing seqRunType

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/PromoteBanked.java
+++ b/src/main/java/org/mskcc/limsrest/service/PromoteBanked.java
@@ -90,9 +90,6 @@ public class PromoteBanked extends LimsTask {
         if (!"Tumor".equals(tumorOrNormal) && !"Normal".equals(tumorOrNormal))
             return;
 
-        String seqRunType = "PE100";
-        seqRequirementMap.put("SequencingRunType", seqRunType);
-
         boolean normal = "Normal".equals(tumorOrNormal);
         int coverageTarget = 0;
         double requestedReads = 0.0;
@@ -554,9 +551,15 @@ public class PromoteBanked extends LimsTask {
             String recipe = (String) bankedFields.getOrDefault("Recipe", "");
             String tumorOrNormal = (String)bankedFields.getOrDefault("TumorOrNormal", null);
             Object capturePanel = bankedFields.getOrDefault("CapturePanel", null);
-            Object seqRunType = bankedFields.getOrDefault("RunType", null);
             Object species = bankedFields.getOrDefault("Species", null);
             Object requestedCoverage = bankedFields.getOrDefault("RequestedCoverage", null);
+
+            // Take runtype from "BankedSample" record. Default to "PE100" if not present
+            Object seqRunType = bankedFields.getOrDefault("RunType", null);
+            if(seqRunType == null){
+                seqRunType = "PE100";
+            }
+            seqRequirementMap.put("SequencingRunType", seqRunType);
 
             // banked Sample requested reads is a string, but a double in seqRequirement
             String requestedReads = bankedSample.getRequestedReads();

--- a/src/test/java/org/mskcc/limsrest/service/PromoteBankedTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/PromoteBankedTest.java
@@ -6,7 +6,6 @@ import com.velox.api.datarecord.DataRecordManager;
 import com.velox.api.datarecord.IoError;
 import com.velox.api.datarecord.NotFound;
 import com.velox.api.user.User;
-import com.velox.sapioutils.client.standalone.VeloxConnection;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
@@ -62,35 +61,39 @@ public class PromoteBankedTest {
 
     @Test
     public void setSeqRequirementsIMPACT() {
-        HashMap<String, Object> map = new HashMap<>();
-        PromoteBanked.setSeqReq("IMPACT468", "Tumor", map);
-        assertEquals("PE100", map.get("SequencingRunType"));
-        assertEquals(14.0, map.get("RequestedReads"));
-        assertEquals(500, map.get("CoverageTarget"));
+        Map<String, Number> map1 = PromoteBanked.getCovReadsRequirementsMap("IMPACT468","Tumor", "");
+        assertEquals(14.0, map1.get("RequestedReads"));
+        assertEquals(500, map1.get("CoverageTarget"));
 
-        PromoteBanked.setSeqReq("M-IMPACT_v1", "Tumor", map);
-        assertEquals("PE100", map.get("SequencingRunType"));
-        assertEquals(14.0, map.get("RequestedReads"));
-        assertEquals(500, map.get("CoverageTarget"));
+        Map<String, Number> map2 = PromoteBanked.getCovReadsRequirementsMap("M-IMPACT_v1", "Tumor", "");
+        assertEquals(14.0, map2.get("RequestedReads"));
+        assertEquals(500, map2.get("CoverageTarget"));
 
-        PromoteBanked.setSeqReq("IMPACT468", "Normal", map);
-        assertEquals("PE100", map.get("SequencingRunType"));
-        assertEquals(7.0, map.get("RequestedReads"));
-        assertEquals(250, map.get("CoverageTarget"));
+        Map<String, Number> map3 = PromoteBanked.getCovReadsRequirementsMap("IMPACT468", "Normal", "");
+        assertEquals(7.0, map3.get("RequestedReads"));
+        assertEquals(250, map3.get("CoverageTarget"));
     }
 
     @Test
     public void setSeqRequirementsHemePACT() {
-        HashMap<String, Object> map = new HashMap<>();
-        PromoteBanked.setSeqReq("HemePACT", "Tumor", map);
-        assertEquals("PE100", map.get("SequencingRunType"));
+        Map<String, Number> map = PromoteBanked.getCovReadsRequirementsMap("HemePACT", "Tumor", "");
         assertEquals(20.0, map.get("RequestedReads"));
         assertEquals(500, map.get("CoverageTarget"));
 
-        PromoteBanked.setSeqReq("HemePACT", "Normal", map);
-        assertEquals("PE100", map.get("SequencingRunType"));
-        assertEquals(10.0, map.get("RequestedReads"));
-        assertEquals(250, map.get("CoverageTarget"));
+        Map<String, Number> map2 = PromoteBanked.getCovReadsRequirementsMap("HemePACT", "Normal", "");
+        assertEquals(10.0, map2.get("RequestedReads"));
+        assertEquals(250, map2.get("CoverageTarget"));
+    }
+
+    @Test
+    public void setSeqRequirementsBasedOnBankedSample() {
+        Map<String, Number> map = PromoteBanked.getCovReadsRequirementsMap("RNASeq_PolyA", "Tumor", "30-40 million");
+        assertEquals(40.0, map.get("RequestedReads"));
+        assertEquals(0, map.get("CoverageTarget"));
+
+        Map<String, Number> map2 = PromoteBanked.getCovReadsRequirementsMap("RNASeq_PolyA", "Normal", "20-30 million");
+        assertEquals(30.0, map2.get("RequestedReads"));
+        assertEquals(0, map2.get("CoverageTarget"));
     }
 
     @Test


### PR DESCRIPTION
**Bug**: `RequestedReads` & `SequencingRunType` are overridden (see below - these values are not populated (`SequencingRunType` should have been PE50). This is because a map used to update a promoted sample, is not populated w/ values that come from the BankedSample.
 - [RequestedReads](https://github.com/mskcc/LimsRest/blob/575f408e822595588e4d81b89a4be8426d97a27b/src/main/java/org/mskcc/limsrest/service/PromoteBanked.java#L579) &  [seqRunType](https://github.com/mskcc/LimsRest/blob/575f408e822595588e4d81b89a4be8426d97a27b/src/main/java/org/mskcc/limsrest/service/PromoteBanked.java#L557) are overridden by [setSeqReq](https://github.com/mskcc/LimsRest/blob/575f408e822595588e4d81b89a4be8426d97a27b/src/main/java/org/mskcc/limsrest/service/PromoteBanked.java#L581)

_log_
```
25-Nov-2020 17:15:13.947 INFO [pool-105-thread-1] org.mskcc.limsrest.service.promote.BankedSampleToSampleConverter.convert Using uuid: A6R-CY6 for sample: 10924_C_18
2020-11-25 17:15:13.977  INFO 2748 --- [ol-105-thread-1] o.mskcc.limsrest.service.PromoteBanked   : Sequencing Requirements before Coverage -> Reads conversion logic run: {OtherSampleId=MDAMB231DJ1KD_3, CoverageTarget=0, RequestedReads=0.0, SequencingRun
Type=PE100, SampleId=10924_C_18}
```

**Fix**: Write a single method (`getCovReadsRequirementsMap`) that calculates the `requestedReads` and `coverageTarget` rather than populate a map that is passed in w/ practice modifying the map in other places