### PR TITLE
Adding back coverage/requested_reads logic for WES requests

### DIFF
--- a/src/test/java/org/mskcc/limsrest/service/PromoteBankedTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/PromoteBankedTest.java
@@ -98,33 +98,20 @@ public class PromoteBankedTest {
 
     @Test
     public void setSeqRequirementsWES_whenRequestReadsIsValid() {
-        Map<String, Object> seqRequirementMap = new HashMap<>();
-        promoteBanked.setSeqReqForWES("100X", seqRequirementMap);
-        Assertions.assertThat(seqRequirementMap).hasSize(3);
-        Assertions.assertThat(seqRequirementMap).containsKeys("SequencingRunType", "CoverageTarget", "RequestedReads");
-        Assertions.assertThat(seqRequirementMap).containsEntry("SequencingRunType", "PE100");
+        Map<String, Number> seqRequirementMap = promoteBanked.getCovReadsRequirementsMap_forWES("100X");
+        Assertions.assertThat(seqRequirementMap).hasSize(2);
+        Assertions.assertThat(seqRequirementMap).containsKeys("CoverageTarget", "RequestedReads");
         Assertions.assertThat(seqRequirementMap).containsEntry("CoverageTarget", 100);
         Assertions.assertThat(seqRequirementMap).containsEntry("RequestedReads", 60.0);
     }
 
     @Test
     public void setSeqRequirementWES_whenCoverageTargetIsNotInMap() {
-        Map<String, Object> seqRequirementMap = new HashMap<>();
-        promoteBanked.setSeqReqForWES("1000X", seqRequirementMap);
-        Assertions.assertThat(seqRequirementMap).hasSize(3);
-        Assertions.assertThat(seqRequirementMap).containsKeys("SequencingRunType", "CoverageTarget", "RequestedReads");
-        Assertions.assertThat(seqRequirementMap).containsEntry("SequencingRunType", "PE100");
+        Map<String, Number> seqRequirementMap = promoteBanked.getCovReadsRequirementsMap_forWES("1000X");
+        Assertions.assertThat(seqRequirementMap).hasSize(2);
+        Assertions.assertThat(seqRequirementMap).containsKeys("CoverageTarget", "RequestedReads");
         Assertions.assertThat(seqRequirementMap).containsEntry("CoverageTarget", 1000);
         Assertions.assertThat(seqRequirementMap).containsEntry("RequestedReads", null);
-    }
-
-    @Test
-    public void setSeqRequirementWES_whenRequestedReadsIsEmpty() {
-        Map<String, Object> seqRequirementMap = new HashMap<>();
-        promoteBanked.setSeqReqForWES("", seqRequirementMap);
-        Assertions.assertThat(seqRequirementMap).hasSize(1);
-        Assertions.assertThat(seqRequirementMap).containsKeys("SequencingRunType");
-        Assertions.assertThat(seqRequirementMap).containsEntry("SequencingRunType", "PE100");
     }
 
     @Test


### PR DESCRIPTION
**Bug**: `setSeqReqForWES` was removed in https://github.com/mskcc/LimsRest/pull/205/files
**Fix**: Add back this Logic