### PR TITLE
Return labHeadEmail and isCmo or isBic from LIMS.

### DIFF
--- a/src/main/java/org/mskcc/limsrest/controller/GetRequestPermissions.java
+++ b/src/main/java/org/mskcc/limsrest/controller/GetRequestPermissions.java
@@ -1,0 +1,53 @@
+package org.mskcc.limsrest.controller;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mskcc.limsrest.ConnectionLIMS;
+import org.mskcc.limsrest.service.GetRequestPermissionsTask;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Used to query what permissions should be granted to fastqs at the time of delivery:
+ * - returns the "PI" aka "LAB NAME" such as 'peerd'
+ * - returns the groups that need read access whether it is a CMO project, BIC project and data access emails
+ */
+@RestController
+@RequestMapping("/")
+public class GetRequestPermissions {
+    private final static Log log = LogFactory.getLog(GetRequestPermissions.class);
+
+    private final ConnectionLIMS conn;
+
+    public GetRequestPermissions(ConnectionLIMS conn) {
+        this.conn = conn;
+    }
+
+    @GetMapping("/getRequestPermissions")
+    public GetRequestPermissionsTask.RequestPermissions getContent(@RequestParam(value = "request") String requestId, HttpServletRequest request) {
+        log.info("/getRequestPermissions for request:" + requestId + " " + request.getRemoteAddr());
+
+        if (!Whitelists.requestMatches(requestId)) {
+            log.error("FAILURE: requestId is not using a valid format.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "FAILURE: requestId is not using a valid format.");
+        }
+
+        try {
+            GetRequestPermissionsTask t = new GetRequestPermissionsTask(requestId, conn);
+            GetRequestPermissionsTask.RequestPermissions x = t.execute();
+            if (x == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, requestId + " Request Not Found");
+            }
+            return x;
+        } catch (Exception e) {
+            log.error(e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/mskcc/limsrest/service/GetRequestPermissionsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestPermissionsTask.java
@@ -44,20 +44,32 @@ public class GetRequestPermissionsTask {
 
             Boolean isCmoRequest = Boolean.FALSE;
             Boolean bicAnalysis = Boolean.FALSE;
+            String analysisType = "";
             try {
                 isCmoRequest = dataRecord.getBooleanVal("IsCmoRequest", user);
                 bicAnalysis = dataRecord.getBooleanVal("BICAnalysis", user);
+                analysisType = dataRecord.getStringVal("AnalysisType", user);
             } catch (NullPointerException e) {
                 log.warn("Correct invalid null valid in database for request: " + requestId);
             }
 
+            Boolean isBicRequest = isBicRequest(analysisType, bicAnalysis);
+
             String labName = labHeadEmailToLabName(labHeadEmail);
 
-            return new RequestPermissions(requestId, labName, labHeadEmail, isCmoRequest, bicAnalysis, dataAccessEmails);
+            return new RequestPermissions(requestId, labName, labHeadEmail, isCmoRequest, isBicRequest, dataAccessEmails);
         } catch (Throwable e) {
             log.error(e.getMessage(), e);
             return null;
         }
+    }
+
+    protected static Boolean isBicRequest(String analysisType, Boolean bicAnalysis) {
+        // historically Request.BICAnalysis was set until the end of 2019
+        // when the Request.AnalysisType field could have "BIC" or "FASTQ ONLY" or other groups.
+        if (bicAnalysis || "BIC".equalsIgnoreCase(analysisType))
+            return true;
+        return false;
     }
 
     protected static String labHeadEmailToLabName(String labHeadEmail) {
@@ -101,16 +113,16 @@ public class GetRequestPermissionsTask {
         public String labName;
         public String labHeadEmail;
         public Boolean isCmoRequest;
-        public Boolean bicAnalysis;
+        public Boolean isBicRequest;
         public String dataAccessEmails;
 
         public RequestPermissions(String requestId, String labName, String labHeadEmail,
-                                  Boolean isCmoRequest, Boolean bicAnalysis, String dataAccessEmails) {
+                                  Boolean isCmoRequest, Boolean isBicRequest, String dataAccessEmails) {
             this.requestId = requestId;
             this.labName = labName;
             this.labHeadEmail = labHeadEmail;
             this.isCmoRequest = isCmoRequest;
-            this.bicAnalysis = bicAnalysis;
+            this.isBicRequest = isBicRequest;
             this.dataAccessEmails = dataAccessEmails;
         }
     }

--- a/src/main/java/org/mskcc/limsrest/service/GetRequestPermissionsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestPermissionsTask.java
@@ -1,0 +1,117 @@
+package org.mskcc.limsrest.service;
+
+import com.velox.api.datarecord.DataRecord;
+import com.velox.api.datarecord.DataRecordManager;
+import com.velox.api.user.User;
+import com.velox.sapioutils.client.standalone.VeloxConnection;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mskcc.limsrest.ConnectionLIMS;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Queries the LIMS for fields important to fastq.gz data access permissions.
+ */
+public class GetRequestPermissionsTask {
+    private static Log log = LogFactory.getLog(GetRequestPermissionsTask.class);
+
+    private ConnectionLIMS conn;
+    private String requestId;
+
+    public GetRequestPermissionsTask(String requestId, ConnectionLIMS conn) {
+        this.requestId = requestId;
+        this.conn = conn;
+    }
+
+    public GetRequestPermissionsTask.RequestPermissions execute() {
+        try {
+            VeloxConnection vConn = conn.getConnection();
+            User user = vConn.getUser();
+            DataRecordManager drm = vConn.getDataRecordManager();
+
+            List<DataRecord> requestList = drm.queryDataRecords("Request", "RequestId = '" + this.requestId + "'", user);
+            if (requestList.size() != 1) {  // error: request ID not found or more than one found
+                log.error("Request not found:" + requestId);
+                return null;
+            }
+
+            DataRecord dataRecord = requestList.get(0);
+            String dataAccessEmails = dataRecord.getStringVal("DataAccessEmails", user);
+            String labHeadEmail = dataRecord.getStringVal("LabHeadEmail", user).toLowerCase();
+
+            Boolean isCmoRequest = Boolean.FALSE;
+            Boolean bicAnalysis = Boolean.FALSE;
+            try {
+                isCmoRequest = dataRecord.getBooleanVal("IsCmoRequest", user);
+                bicAnalysis = dataRecord.getBooleanVal("BICAnalysis", user);
+            } catch (NullPointerException e) {
+                log.warn("Correct invalid null valid in database for request: " + requestId);
+            }
+
+            String labName = labHeadEmailToLabName(labHeadEmail);
+
+            return new RequestPermissions(requestId, labName, labHeadEmail, isCmoRequest, bicAnalysis, dataAccessEmails);
+        } catch (Throwable e) {
+            log.error(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    protected static String labHeadEmailToLabName(String labHeadEmail) {
+        if (emailToLabMap.containsKey(labHeadEmail))
+            return emailToLabMap.get(labHeadEmail);
+        // there are 10 old LIMS projects with a @sloankettering.edu labHeadEmail address
+        else if (labHeadEmail.endsWith("@mskcc.org") || labHeadEmail.endsWith("@sloankettering.edu"))
+            return labHeadEmail.split("@")[0];
+        else
+            return labHeadEmail.split("@")[0] + "_EXTERNAL";
+    }
+
+    protected static Map<String, String> emailToLabMap = new HashMap<>();
+    static {
+        // this table could move to ngs-stats DB if updates are frequent/necessary
+        // this endpoint would then just return the labHeadEmail and not the lab share folder name
+        emailToLabMap.put("a-haimovitz-friedman@ski.mskcc.org", "haimovia");
+        emailToLabMap.put("a-zelenetz@mskcc.org", "zeleneta");
+        emailToLabMap.put("a-zelenetz@ski.mskcc.org", "zeleneta");
+        emailToLabMap.put("d-scheinberg@ski.mskcc.org", "scheinbd");
+        emailToLabMap.put("f-giancotti@ski.mskcc.org", "giancotf");
+        emailToLabMap.put("j-massague@ski.mskcc.org", "massaguej");
+        emailToLabMap.put("k-anderson@ski.mskcc.org", "kanderson");
+        emailToLabMap.put("m-baylies@ski.mskcc.org", "bayliesm");
+        emailToLabMap.put("m-jasin@ski.mskcc.org", "jasinm");
+        emailToLabMap.put("m-mcdevitt@ski.mskcc.org", "m-mcdevitt");
+        emailToLabMap.put("m-moore@ski.mskcc.org", "moorem");
+        emailToLabMap.put("m-ptashne@ski.mskcc.org", "ptashne");
+        emailToLabMap.put("m-sadelain@ski.mskcc.org", "sadelaim");
+        emailToLabMap.put("m-van-den-brink@ski.mskcc.org", "vandenbm");
+        emailToLabMap.put("p-tempst@ski.mskcc.org", "tempstp");
+        emailToLabMap.put("r-benezra@ski.mskcc.org", "benezrar");
+        emailToLabMap.put("r-kolesnick@ski.mskcc.org", "rkolesnick");
+        emailToLabMap.put("s-keeney@ski.mskcc.org", "keeneys");
+        emailToLabMap.put("s-shuman@ski.mskcc.org", "sshuman");
+        emailToLabMap.put("w-mark@ski.mskcc.org", "markw");
+    }
+
+    public static class RequestPermissions {
+        public String requestId;
+        public String labName;
+        public String labHeadEmail;
+        public Boolean isCmoRequest;
+        public Boolean bicAnalysis;
+        public String dataAccessEmails;
+
+        public RequestPermissions(String requestId, String labName, String labHeadEmail,
+                                  Boolean isCmoRequest, Boolean bicAnalysis, String dataAccessEmails) {
+            this.requestId = requestId;
+            this.labName = labName;
+            this.labHeadEmail = labHeadEmail;
+            this.isCmoRequest = isCmoRequest;
+            this.bicAnalysis = bicAnalysis;
+            this.dataAccessEmails = dataAccessEmails;
+        }
+    }
+}

--- a/src/test/java/org/mskcc/limsrest/service/GetRequestPermissionsTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetRequestPermissionsTaskTest.java
@@ -1,0 +1,24 @@
+package org.mskcc.limsrest.service;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GetRequestPermissionsTaskTest {
+
+    @Test
+    public void labHeadEmailToLabNameSpecialEmail() {
+        assertEquals("massaguej", GetRequestPermissionsTask.labHeadEmailToLabName("j-massague@ski.mskcc.org"));
+    }
+
+    @Test
+    public void labHeadEmailToLabNameNormalEmail() {
+        assertEquals("persona", GetRequestPermissionsTask.labHeadEmailToLabName("persona@mskcc.org"));
+        assertEquals("kmariens", GetRequestPermissionsTask.labHeadEmailToLabName("kmariens@sloankettering.edu"));
+    }
+
+    @Test
+    public void labHeadEmailToLabNameBlankEmail() {
+        assertEquals("_EXTERNAL", GetRequestPermissionsTask.labHeadEmailToLabName(""));
+    }
+}


### PR DESCRIPTION
Created a separate endpoint for information needed to set folder permissions at time of delivery - currently access permissions depend on these Request level LIMS fields:
        String requestId;
        String labName; (derived from labHeadEmail)
        String labHeadEmail;
        Boolean isCmoRequest;
        Boolean bicAnalysis;
        String dataAccessEmails;