### PR TITLE
Adding dueDate to requestSummary

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetIgoRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetIgoRequestsTask.java
@@ -93,6 +93,7 @@ public class GetIgoRequestsTask extends LimsTask {
             rs.setIsIgoComplete(isIgoComplete(request, user));
             rs.setQcAccessEmail(getRecordStringValue(request, "QcAccessEmails", user));
             rs.setDataAccessEmails(getRecordStringValue(request, "DataAccessEmails", user));
+            rs.setDueDate(getRecordLongValue(request, "DueDate", user));
             requests.add(rs);
         }
 

--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -33,7 +33,7 @@ import static org.mskcc.limsrest.util.Utils.*;
 public class GetRequestTrackingTask {
     private static Log log = LogFactory.getLog(GetRequestTrackingTask.class);
 
-    private static String[] requestDataLongFields = new String[]{RequestModel.RECEIVED_DATE};
+    private static String[] requestDataLongFields = new String[]{RequestModel.RECEIVED_DATE, "DueDate"};
     private static String[] requestDataStringFields = new String[]{
             RequestModel.LABORATORY_HEAD,
             RequestModel.GROUP_LEADER,
@@ -43,7 +43,7 @@ public class GetRequestTrackingTask {
             RequestModel.LAB_HEAD_EMAIL,
             RequestModel.INVESTIGATOR,
             RequestModel.PROJECT_NAME,
-            RequestModel.REQUEST_NAME,
+            RequestModel.REQUEST_NAME
 
     };
     private ConnectionLIMS conn;

--- a/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
+++ b/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
@@ -27,6 +27,7 @@ public class RequestSummary {
     private Boolean isCmoRequest = Boolean.FALSE;
     private long recordId;
     private Long receivedDate;
+    private Long dueDate;
     private Short sampleNumber;
     private String restStatus;
     private String specialDelivery;
@@ -78,6 +79,15 @@ public class RequestSummary {
 
     public void setReceivedDate(Long receivedDate) {
         this.receivedDate = receivedDate;
+    }
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    public Long getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(Long dueDate) {
+        this.dueDate = dueDate;
     }
 
     @JsonInclude(JsonInclude.Include.ALWAYS)


### PR DESCRIPTION
Adding dueDate to RequestSummary so it is returned in `LimsRest/getIgoRequest`

```
{
"requests": [
   {
      "samples": [],
      "recentDeliveryDate": 1606933762437,
      "completedDate": 1582236522234,
      "requestId": "06302_AG",
      "requestType": "MSK-ACCESS_v1",
      "investigator": "Michael Berger",
      "pi": "Michael Berger",
      "analysisRequested": false,
      "isCmoRequest": false,
      "recordId": 0,
      "receivedDate": null,
      "dueDate": 1582779600000,
      "restStatus": "SUCCESS",
      "labHeadEmail": null,
      "qcAccessEmail": "",
      "dataAccessEmails": "",
      "isIgoComplete": true,
      "autorunnable": false,
      "deliveryDate": []
   },
   ...
}
```