### PR TITLE
Returning volume remaining in sample

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -329,6 +329,8 @@ public class GetRequestTrackingTask {
         ProjectSampleTree rootTree = new ProjectSampleTree(root, user);
         rootTree.addSample(root);
 
+        rootTree.enrich(record);
+
         // Evaluate overall QcStatus of ProjectSample from all descending SeqAnalysisSampleQC entries b/c the rule is
         // simple - if there is an IGO-Complete SeqAnalysisSampleQC record, the projectSample is IgoComplete
         try {

--- a/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSample.java
+++ b/src/main/java/org/mskcc/limsrest/service/requesttracker/ProjectSample.java
@@ -22,12 +22,14 @@ public class ProjectSample {
     boolean complete;
     Boolean failed;
     private Map<String, StageTracker> stages;     // Stages present in the project
+    private Map<String, Object> attributeMap;
     private WorkflowSample root;                        // workflowSamples descend from tree root
 
     public ProjectSample(Long recordId) {
         this.sampleId = recordId;
         this.complete = true;       // The sample is considered complete until a record is added that is not done
         this.stages = new TreeMap<>(new StageComp());
+        this.attributeMap = new HashMap<>();
     }
 
     public WorkflowSample getRoot() {
@@ -80,6 +82,14 @@ public class ProjectSample {
         return this.record;
     }
 
+    /**
+     * Adds attributes of the physical sample (not a workflow sample)
+     *
+     * @param attributeMap
+     */
+    public void addAttributes(Map<String, Object> attributeMap){
+        this.attributeMap.putAll(attributeMap);
+    }
 
     /**
      * Needs to be converted into a map to be returned in service response
@@ -95,6 +105,7 @@ public class ProjectSample {
                 stage -> stage.toApiResponse()
         ).collect(Collectors.toList()));
         apiMap.put("root", this.root.toApiResponse());
+        apiMap.put("sampleInfo", this.attributeMap);
 
         return apiMap;
     }

--- a/src/main/java/org/mskcc/limsrest/util/Utils.java
+++ b/src/main/java/org/mskcc/limsrest/util/Utils.java
@@ -323,6 +323,24 @@ public class Utils {
     }
 
     /**
+     * Safely retrieves a Double Value from a dataRecord
+     *
+     * @param record
+     * @param key
+     * @param user
+     * @return
+     */
+    public static Double getRecordDoubleValue(DataRecord record, String key, User user) {
+        try {
+            return record.getDoubleVal(key, user);
+        } catch (NotFound | RemoteException | NullPointerException e) {
+            LOGGER.error(String.format("Failed to get (Double) key %s from Sample Record: %d", key, record.getRecordId()));
+        }
+        return null;
+    }
+
+
+    /**
      * Safely retrieves a Short Value from a dataRecord
      *
      * @param record


### PR DESCRIPTION
Returning `volume` (also `concentration` & `concentrationUnits`) of the `ProjectSample` for each sample in a request. This should represent the remaining volume IGO has of that sample

e.g. /LimsRest/getRequestTracking?request=05240_W
```

"samples": [
  {
    "sampleId": 5278777,
    "root": {},
    "stages": [],
    "sampleInfo": {
      "volume": 14.22680412371134,
      "concentration": 19.4,
      "concentrationUnits": "ng/uL"
    },
    "status": "Pending"
},
```