### PR TITLE
Adding DNA & Library Volume Quantities

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetRequestTrackingTask.java
@@ -232,6 +232,13 @@ public class GetRequestTrackingTask {
     private ProjectSampleTree createWorkflowTree(WorkflowSample root, ProjectSampleTree tree) {
         tree.addStageToTracked(root);   // Update tree Project Sample stages w/ the input Workflow sample's stage
 
+
+        // Add any DNA updates
+        String rStage = root.getStage();
+        if(STAGE_LIBRARY_PREP.equals(rStage) || STAGE_LIBRARY_CAPTURE.equals(rStage)){
+            tree.enrichQuantity(root.getRecord(), rStage);
+        }
+
         if (hasFailedQcStage(root)) {
             root.setFailed(Boolean.TRUE);
             tree.markFailedBranch(root);
@@ -337,8 +344,6 @@ public class GetRequestTrackingTask {
         WorkflowSample root = new WorkflowSample(record, this.conn);
         ProjectSampleTree rootTree = new ProjectSampleTree(root, user);
         rootTree.addSample(root);
-
-        rootTree.enrich(record);
 
         // Evaluate overall QcStatus of ProjectSample from all descending SeqAnalysisSampleQC entries b/c the rule is
         // simple - if there is an IGO-Complete SeqAnalysisSampleQC record, the projectSample is IgoComplete

--- a/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/GetRequestTrackingTaskTest.java
@@ -260,6 +260,36 @@ public class GetRequestTrackingTaskTest {
         validateDeliveredStatus(unDeliveredRequests, false);
     }
 
+    @Test
+    public void testMaterialResponse_libPrepDNA() throws Exception {
+        String requestId = "10828_B";
+        GetRequestTrackingTask t = new GetRequestTrackingTask(requestId, this.conn);
+        Map<String, Object> requestInfo = new HashMap<>();
+        try {
+            requestInfo = t.execute();
+        } catch (IoError | RemoteException | NotFound e) {
+            assertTrue("Exception in task execution", false);
+        }
+        List<Map<String, Object>> stages = (List<Map<String, Object>>) requestInfo.get("stages");
+        assertEquals("Only stage present should be libPrep b/c only DNA should be returned", "Library Preparation", stages.get(0).get("stage"));
+
+        List<Map<String, Object>> samples = (List<Map<String, Object>>) requestInfo.get("samples");
+        assertEquals(1, samples.size());
+        Map<String, Object> sampleInfo = (Map<String, Object>) samples.get(0).get("sampleInfo");
+        Map<String, Object> libraryMaterial = (Map<String, Object>) sampleInfo.get("library_material");
+        Map<String, Object> dnaMaterial = (Map<String, Object>) sampleInfo.get("dna_material");
+
+        assertEquals("Library should have 0 volume", 0D, libraryMaterial.get("volume"));
+        assertEquals("Library should have 0 mass", 0D, libraryMaterial.get("mass"));
+        assertEquals("Library should have 0 concentration", 0D, libraryMaterial.get("concentration"));
+        assertEquals("Library shouldn't have populated concentrationUnits", "", libraryMaterial.get("concentrationUnits"));
+
+        assertEquals("dna should have populated volume", 100D, dnaMaterial.get("volume"));
+        assertEquals("dna should have populated mass", 500D, dnaMaterial.get("mass"));
+        assertEquals("dna should have populated concentration", 5D, dnaMaterial.get("concentration"));
+        assertEquals("dna should have populated concentrationUnits", "ng/uL", dnaMaterial.get("concentrationUnits"));
+    }
+
     /**
      * Validates the isDelivered status of the request responses
      *


### PR DESCRIPTION
Updating sample mass/vol/conc during tree traversal to get DNA & Lib quantities



Old
```
"samples":[
   {
      "sampleId":6921242,
      "root":{ ... },
      "stages":[ ... ],
      "sampleInfo":{
         "volume":46.99749180783772,
         "concentration":398.69353514367833,
         "concentrationUnits":"ng/uL"
      },
      "status":"STR PCR"
   }
]
```

New
```
"samples":[
   {
      "sampleId":6921242,
      "root":{ ... },
      "stages":[ ...],
      "sampleInfo":{
         "library_material":{
            "volume":0,
            "mass":0,
            "concentration":0,
            "concentrationUnits":""
         },
         "dna_material":{
            "volume":100,
            "mass":500,
            "concentration":5,
            "concentrationUnits":"ng/uL"
         }
      },
      "status":"Library Preparation"
   }
]
```