### PR TITLE
Adding runFolders to RequestSummary

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -8,6 +8,8 @@ import com.velox.api.user.User;
 import com.velox.api.util.ServerException;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
 import com.velox.sloan.cmo.recmodels.FlowCellLaneModel;
+import com.velox.sloan.cmo.recmodels.IlluminaSeqExperimentModel;
+import com.velox.sloan.cmo.recmodels.IlluminaSeqProtocolModel;
 import com.velox.sloan.cmo.recmodels.RequestModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -15,12 +17,15 @@ import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.mskcc.limsrest.util.StatusTrackerConfig.isIgoComplete;
 import static org.mskcc.limsrest.util.Utils.getRecordLongValue;
 import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
+import static org.mskcc.limsrest.util.Utils.getDescendantsOfType;
 
 public class GetSequencingRequestsTask extends LimsTask {
     private static Log log = LogFactory.getLog(GetIgoRequestsTask.class);
@@ -31,6 +36,40 @@ public class GetSequencingRequestsTask extends LimsTask {
     public GetSequencingRequestsTask(Long days, Boolean delivered) {
         this.days = days;
         this.delivered = delivered;
+    }
+
+    /**
+     * Retrieves the sequencing run folders of the input Request DataRecord instance
+     *
+     *      Request > ... > IlluminaSeqProtocol
+     *      IlluminaSeqProtocol -> IlluminaSeqExperiment
+     *      IlluminaSeqExperiment::SequencerRunFolder
+     *
+     * @param drm
+     * @param request
+     * @param user
+     * @return
+     */
+    private List<String> getSequencingFoldersOfRequest(DataRecordManager drm, DataRecord request, User user) {
+        List<DataRecord> seqExperiments = getDescendantsOfType(request, IlluminaSeqProtocolModel.DATA_TYPE_NAME, user);
+        List<String> experimentIds = seqExperiments.stream().map((exp) -> {
+            Long expId = getRecordLongValue(exp, IlluminaSeqProtocolModel.EXPERIMENT_RECORD_ID, user);
+            return expId.toString();
+        }).distinct().collect(Collectors.toList());
+        String query = String.format("%s in (%s)", IlluminaSeqExperimentModel.RECORD_ID, String.join(",", experimentIds));
+        List<DataRecord> illuminaSeqExperiments = new ArrayList<>();
+        try {
+            illuminaSeqExperiments = drm.queryDataRecords(IlluminaSeqExperimentModel.DATA_TYPE_NAME, query, user);
+        } catch (IoError | RemoteException | NotFound e) {
+            log.error(String.format("Failed to query DataRecords w/ query: '%s' on %s", query,
+                    IlluminaSeqExperimentModel.DATA_TYPE_NAME));
+            return new ArrayList<>();
+        }
+        List<String> runFolders = illuminaSeqExperiments.stream().map(
+                seqExpRecord -> getRecordStringValue(seqExpRecord, IlluminaSeqExperimentModel.SEQUENCER_RUN_FOLDER, user))
+                .collect(Collectors.toList());
+
+        return runFolders;
     }
 
     @PreAuthorize("hasRole('READ')")
@@ -83,8 +122,11 @@ public class GetSequencingRequestsTask extends LimsTask {
         List<RequestSummary> requests = new ArrayList<>();
 
         for (DataRecord request : requestRecords) {
+            List<String> seqFolders = getSequencingFoldersOfRequest(dataRecordManager, request, user);
+
             String requestId = getRecordStringValue(request, RequestModel.REQUEST_ID, user);
             RequestSummary rs = new RequestSummary(requestId);
+            rs.setRunFolders(seqFolders);
             rs.setInvestigator(getRecordStringValue(request, RequestModel.INVESTIGATOR, user));
             rs.setPi(getRecordStringValue(request, RequestModel.LABORATORY_HEAD, user));
             rs.setRequestType(getRecordStringValue(request, RequestModel.REQUEST_NAME, user));

--- a/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetSequencingRequestsTask.java
@@ -52,10 +52,12 @@ public class GetSequencingRequestsTask extends LimsTask {
      */
     private List<String> getSequencingFoldersOfRequest(DataRecordManager drm, DataRecord request, User user) {
         List<DataRecord> seqExperiments = getDescendantsOfType(request, IlluminaSeqProtocolModel.DATA_TYPE_NAME, user);
-        List<String> experimentIds = seqExperiments.stream().map((exp) -> {
-            Long expId = getRecordLongValue(exp, IlluminaSeqProtocolModel.EXPERIMENT_RECORD_ID, user);
-            return expId.toString();
-        }).distinct().collect(Collectors.toList());
+        List<String> experimentIds = seqExperiments.stream()
+                .map((exp) -> {
+                    Long expId = getRecordLongValue(exp, IlluminaSeqProtocolModel.EXPERIMENT_RECORD_ID, user);
+                    return expId.toString(); })
+                .distinct()
+                .collect(Collectors.toList());
         String query = String.format("%s in (%s)", IlluminaSeqExperimentModel.RECORD_ID, String.join(",", experimentIds));
         List<DataRecord> illuminaSeqExperiments = new ArrayList<>();
         try {
@@ -65,8 +67,11 @@ public class GetSequencingRequestsTask extends LimsTask {
                     IlluminaSeqExperimentModel.DATA_TYPE_NAME));
             return new ArrayList<>();
         }
-        List<String> runFolders = illuminaSeqExperiments.stream().map(
-                seqExpRecord -> getRecordStringValue(seqExpRecord, IlluminaSeqExperimentModel.SEQUENCER_RUN_FOLDER, user))
+        List<String> runFolders = illuminaSeqExperiments.stream()
+                .map(seqExpRecord -> getRecordStringValue(seqExpRecord, IlluminaSeqExperimentModel.SEQUENCER_RUN_FOLDER, user))
+                .filter(seqExpRecord -> {
+                    return !"".equals(seqExpRecord);
+                })
                 .collect(Collectors.toList());
 
         return runFolders;
@@ -123,8 +128,8 @@ public class GetSequencingRequestsTask extends LimsTask {
 
         for (DataRecord request : requestRecords) {
             List<String> seqFolders = getSequencingFoldersOfRequest(dataRecordManager, request, user);
-
             String requestId = getRecordStringValue(request, RequestModel.REQUEST_ID, user);
+
             RequestSummary rs = new RequestSummary(requestId);
             rs.setRunFolders(seqFolders);
             rs.setInvestigator(getRecordStringValue(request, RequestModel.INVESTIGATOR, user));

--- a/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
+++ b/src/main/java/org/mskcc/limsrest/service/RequestSummary.java
@@ -35,6 +35,7 @@ public class RequestSummary {
     private String qcAccessEmail;
     private String dataAccessEmails;
     private Boolean isIgoComplete;
+    private List<String> runFolders;
 
     public RequestSummary() {
         this("UNKNOWN");
@@ -62,6 +63,16 @@ public class RequestSummary {
             this.isCmoRequest = cmoRequest;
         }
     }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public List<String> getRunFolders() {
+        return runFolders;
+    }
+
+    public void setRunFolders(List<String> runFolders) {
+        this.runFolders = runFolders;
+    }
+
 
     @JsonInclude(JsonInclude.Include.ALWAYS)
     public String getDataAccessEmails() {

--- a/src/main/java/org/mskcc/limsrest/util/Utils.java
+++ b/src/main/java/org/mskcc/limsrest/util/Utils.java
@@ -1,13 +1,11 @@
 package org.mskcc.limsrest.util;
 
 import com.velox.api.datarecord.DataRecord;
+import com.velox.api.datarecord.DataRecordManager;
 import com.velox.api.datarecord.IoError;
 import com.velox.api.datarecord.NotFound;
 import com.velox.api.user.User;
-import com.velox.sloan.cmo.recmodels.FlowCellLaneModel;
-import com.velox.sloan.cmo.recmodels.FlowCellModel;
-import com.velox.sloan.cmo.recmodels.SampleModel;
-import com.velox.sloan.cmo.recmodels.SeqAnalysisSampleQCModel;
+import com.velox.sloan.cmo.recmodels.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
@@ -391,6 +389,23 @@ public class Utils {
             LOGGER.error(String.format("Failed to retrieve %s children of %s record: %d", childDataType, record.getDataTypeName(), record.getRecordId()));
         }
         return new DataRecord[0];
+    }
+
+    /**
+     * Returns Datatype descendents of the input DataRecord
+     *
+     * @param record
+     * @param dataType
+     * @param user
+     * @return
+     */
+    public static List<DataRecord> getDescendantsOfType(DataRecord record, String dataType, User user) {
+        try {
+            return record.getDescendantsOfType(dataType, user);
+        } catch (RemoteException e){
+            LOGGER.error(String.format("Failed to retrieve %s descendents of %s record: %d", dataType, record.getDataTypeName(), record.getRecordId()));
+        }
+        return new ArrayList<>();
     }
 
     /**


### PR DESCRIPTION
**Description**: Return a list of the runFolders for each request

```
{
   "requests":[
      {
         "samples":[
            
         ],
         "recentDeliveryDate":1585167978250,
         "requestId":"05500_GL",
         "requestType":"HiSeq-Other",
         "investigator":"Grittney Tam",
         "pi":"Michael Berger",
         "analysisRequested":false,
         "isCmoRequest":false,
         "recordId":0,
         "receivedDate":null,
         "dueDate":null,
         "restStatus":"SUCCESS",
         "labHeadEmail":null,
         "qcAccessEmail":null,
         "dataAccessEmails":null,
         "isIgoComplete":true,
         "runFolders":[
            "/ifs/hiseq/pitt/200313_PITT_0466_BHGKL7BBXY/",
            "/ifs/hiseq/pitt/200319_PITT_0467_AHGJTLBBXY/",
            "/srv/www/sapio/kim/190911_KIM_0750_AH53FMBCX3/"
         ],
         "deliveryDate":[
            
         ],
         "autorunnable":false
      }
   ],
   "status":"Success"
}
```