### PR TITLE
EXCEPTIONALLY_VALID_IGO_IDS

### DIFF
--- a/src/main/java/org/mskcc/limsrest/util/IGOTools.java
+++ b/src/main/java/org/mskcc/limsrest/util/IGOTools.java
@@ -1,6 +1,14 @@
 package org.mskcc.limsrest.util;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 public class IGOTools {
+
+    private static Set<String> EXCEPTIONALLY_VALID_IGO_IDS = new HashSet<String>(
+            Arrays.asList("POOLED_05605_AC_1")
+    );
 
     /**
      * Extract the request id from an IGO id like: 06049_AA_1_2_1
@@ -14,7 +22,8 @@ public class IGOTools {
     }
 
     public static boolean isValidIGOSampleId(String igoId) {
-        return igoId.matches("\\d\\d\\d\\d\\d(_[A-Z]*)?(_[0-9]*)+");
+        return igoId.matches("\\d\\d\\d\\d\\d(_[A-Z]*)?(_[0-9]*)+") ||
+                EXCEPTIONALLY_VALID_IGO_IDS.contains(igoId);
     }
 
     /**


### PR DESCRIPTION
**Description**: POOLED_05605_AC_1 seems invalid (https://igolims.mskcc.org:8443/LimsRest/api/getSampleManifest?igoSampleId=POOLED_05605_AC_1), but it has FASTQs here `/igo/delivery/FASTQ/SCOTT_0331_AHCM3HBGXH/Project_05605_AC/Sample_EEC128_IGO_Pooled-05605_AC_1`

