### PR TITLE
Setting "IsCmoRequest" in /LimsRest/getIgoRequests response

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetIgoRequestsTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetIgoRequestsTask.java
@@ -14,9 +14,8 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mskcc.limsrest.util.Utils.getRecordLongValue;
-import static org.mskcc.limsrest.util.Utils.getRecordStringValue;
 import static org.mskcc.limsrest.util.StatusTrackerConfig.isIgoComplete;
+import static org.mskcc.limsrest.util.Utils.*;
 
 public class GetIgoRequestsTask extends LimsTask {
     private static Log log = LogFactory.getLog(GetIgoRequestsTask.class);
@@ -84,6 +83,7 @@ public class GetIgoRequestsTask extends LimsTask {
         for (DataRecord request : records) {
             String requestId = getRecordStringValue(request, RequestModel.REQUEST_ID, user);
             RequestSummary rs = new RequestSummary(requestId);
+            rs.setIsCmoRequest(getRecordBooleanValue(request, "IsCmoRequest", user));
             rs.setInvestigator(getRecordStringValue(request, RequestModel.INVESTIGATOR, user));
             rs.setPi(getRecordStringValue(request, RequestModel.LABORATORY_HEAD, user));
             rs.setRequestType(getRecordStringValue(request, RequestModel.REQUEST_NAME, user));


### PR DESCRIPTION
**DESCRIPTION**: `isCmoRequest` defaults to true in `RequestSummary.java` API instances if not populated. This makes the response from `/LimsRest/getIgoRequests` confusing for users are using this field. This change populates this field

**TESTING**
```
{
   "requests":[
      {
         "samples":[],
         "recentDeliveryDate":1623102652121,
         "requestId":"08822_FB",
         "requestType":"PED-PEG",
         "investigator":"Shanita Li",
         "pi":"Neerav Shukla",
         "analysisRequested":false,
         "isCmoRequest":true,                                           <- TRUE
         "recordId":0,
         "receivedDate":1565625252135,
         "dueDate":1566792000000,
         "restStatus":"SUCCESS",
         "labHeadEmail":null,
         "qcAccessEmail":"",
         "dataAccessEmails":"",
         "isIgoComplete":true,
         "autorunnable":false,
         "deliveryDate":[
            
         ]
      },
      {
         "samples":[],
         "recentDeliveryDate":1623250978122,
         "requestId":"11506",
         "requestType":"DLP",
         "investigator":"Stella Paffenholz",
         "pi":"Scott Lowe",
         "analysisRequested":false,
         "isCmoRequest":false,                                         <- FALSE
         "recordId":0,
         "receivedDate":1606854231030,
         "dueDate":1609218000000,
         "restStatus":"SUCCESS",
         "labHeadEmail":null,
         "qcAccessEmail":"paffenhs@mskcc.org,mcphera1@mskcc.org,ivazquezg@gmail.com,limj@mskcc.org",
         "dataAccessEmails":"paffenhs@mskcc.org,mcphera1@mskcc.org,ivazquezg@gmail.com,limj@mskcc.org",
         "isIgoComplete":true,
         "autorunnable":false,
         "deliveryDate":[]
      },
      ...
   ]
}
```