### PR TITLE
Avoiding overloading the response headers with error messages

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/PromoteBanked.java
+++ b/src/main/java/org/mskcc/limsrest/service/PromoteBanked.java
@@ -30,8 +30,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.mskcc.limsrest.util.Utils.selectLarger;
-
 
 /**
  * A queued task that takes banked ids, a service id and optionally a request  and project.
@@ -263,8 +261,16 @@ public class PromoteBanked extends LimsTask {
                 log.error(e);
 
                 MultiValueMap<String, String> headers = new HttpHeaders();
+
+                // Avoid HeadersTooLargeException
+                String errMessage = e.getMessage();
+                String headerErr = "";
+                if(errMessage != null){
+                    headerErr = errMessage.substring(0,Math.min(500,errMessage.length()));
+                }
+
                 headers.add(Constants.ERRORS,
-                        Messages.ERROR_IN + " PROMOTING BANKED SAMPLE: " + e.toString() + ": " + e.getMessage());
+                        Messages.ERROR_IN + " PROMOTING BANKED SAMPLE: " + headerErr);
 
                 return new ResponseEntity<>(headers, HttpStatus.OK);
             }


### PR DESCRIPTION
**Description**: Headers are sometimes being overloaded in error requests for `/promoteBankedSample`. This can cause misleading error responses, "Cannot forward to error page for request [/promoteBankedSample] as the response has already been committed. As a result, the response may have the wrong status code".
This may be causing slowness and timeout issues reported in promote and having to retry promote logic reported on 6/15/21. Either way, these error messages aren't able to be sent because they overload the response headers.

**ERROR**
```
2021-06-15 12:10:02.890 ERROR 48464 --- [o-8443-exec-366] o.s.b.w.servlet.support.ErrorPageFilter  : Cannot forward to error page for request [/promoteBankedSample] as the response has already been committed. As a result, the response may have the wrong status code. If your application is running on WebSphere Application Server you may be able to resolve this problem by setting com.ibm.ws.webcontainer.invokeFlushAfterService to false

org.apache.coyote.http11.HeadersTooLargeException: An attempt was made to write more data to the response headers than there was room available in the buffer. Increase maxHttpHeaderSize on the connector or write less data into the response headers.
--
--
2021-06-15 14:22:22.692 ERROR 48464 --- [o-8443-exec-393] o.s.b.w.servlet.support.ErrorPageFilter  : Cannot forward to error page for request [/promoteBankedSample] as the response has already been committed. As a result, the response may have the wrong status code. If your application is running on WebSphere Application Server you may be able to resolve this problem by setting com.ibm.ws.webcontainer.invokeFlushAfterService to false

org.apache.coyote.http11.HeadersTooLargeException: An attempt was made to write more data to the response headers than there was room available in the buffer. Increase maxHttpHeaderSize on the connector or write less data into the response headers.
--
```