### PR TITLE
Update metadb dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,8 +78,8 @@ configurations {
 
 dependencies {
     // cmo metadb messaging library dependency added with jitpack
-    implementation('com.github.mskcc:cmo-messaging-java:e01088f714e7f77e2187e1ed5943789a2cacb415')
-    implementation('com.github.mskcc:cmo-metadb-common:1.1.7.RELEASE')
+    implementation('com.github.mskcc:cmo-messaging-java:1.2.2.RELEASE')
+    implementation('com.github.mskcc:cmo-metadb-common:1.2.2.RELEASE')
     implementation 'com.google.code.gson:gson:2.8.6'
 
     implementation 'org.mskcc.common:common-domain:2.14'

--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,12 @@
     <dependency>
       <groupId>com.github.mskcc</groupId>
       <artifactId>cmo-messaging-java</artifactId>
-      <version>e01088f714e7f77e2187e1ed5943789a2cacb415</version>
+      <version>1.2.2.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>com.github.mskcc</groupId>
       <artifactId>cmo-metadb-common</artifactId>
-      <version>1.1.7.RELEASE</version>
+      <version>1.2.2.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Latest versions:
- cmo-messaging-java: 1.2.1.RELEASE
- cmo-metadb-common: 1.2.2.RELEASE


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>