### PR TITLE
Update SMILE release versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,8 +78,8 @@ configurations {
 
 dependencies {
     // cmo metadb messaging library dependency added with jitpack
-    implementation('com.github.mskcc:cmo-messaging-java:e01088f714e7f77e2187e1ed5943789a2cacb415')
-    implementation('com.github.mskcc:cmo-metadb-common:1.1.7.RELEASE')
+    implementation('com.github.mskcc:smile-messaging-java:1.3.1.RELEASE')
+    implementation('com.github.mskcc:smile-commons:1.3.1.RELEASE')
     implementation 'com.google.code.gson:gson:2.8.6'
 
     implementation 'org.mskcc.common:common-domain:2.14'


### PR DESCRIPTION
Updated dependency versions for SMILE dependencies (formerly Metadb)


This change also requires a property name to be updated:

`metadb.publishing_failures_filepath` should be renamed to `smile.publishing_failures_filepath` in the app properties file

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>