### PR TITLE
Assigning appropriate status to samples with investigator decision

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
@@ -8,14 +8,15 @@ import com.velox.api.datarecord.InvalidValue;
 import com.velox.api.datarecord.IoError;
 import com.velox.api.datarecord.NotFound;
 import com.velox.api.sqlbuilder.*;
+import com.velox.api.user.User;
 import com.velox.api.util.ServerException;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
+import com.velox.sloan.cmo.staticstrings.datatypes.DT_AssignedProcess;
 import com.velox.sloan.cmo.staticstrings.datatypes.DT_Sample;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.mskcc.limsrest.service.assignedprocess.AssignedProcess;
-import org.mskcc.limsrest.service.assignedprocess.AssignedProcessCreator;
-import org.mskcc.limsrest.service.assignedprocess.QcStatusAwareProcessAssigner;
+import org.mskcc.domain.Workflow;
+import org.mskcc.limsrest.service.assignedprocess.*;
 import org.mskcc.limsrest.util.Messages;
 import org.springframework.security.access.prepost.PreAuthorize;
 
@@ -42,7 +43,14 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
         this.data = data;
 
     }
-
+    public static AssignedProcessConfig getProcessAssignerConfig(String qcStatus, DataRecord sample, User user) throws Exception {
+        switch (qcStatus) {
+            case "Assign from Investigator Decisions":
+                return new ResequencePoolAssignedProcessConfig(sample, user);
+            default:
+                throw new RuntimeException(String.format("Not supported qc status: %s", qcStatus));
+        }
+    }
 
     @PreAuthorize("hasRole('READ')")
     @Override
@@ -58,14 +66,48 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
                 List<DataRecord> matched = dataRecordManager.queryDataRecords(datatype, "RecordId", records, user);
 
                 for (DataRecord match :
-                        matched) {
+                        matched) { //match is of type QC RNA/DNA/Library Report
                     for (Map field : decisions) {
                         if (String.valueOf(match.getRecordId()).equals(String.valueOf(field.get("RecordId")))) {
                             match.setDataField("InvestigatorDecision", field.get("InvestigatorDecision"), user);
                             if(field.get("InvestigatorDecision").toString().toLowerCase().contains("continue processing")) {
-                                String newStatus = "Ready for - Pending User Decision";
-                                match.getParentsOfType("Sample", user).get(0).setDataField(DT_Sample.
-                                        EXEMPLAR_SAMPLE_STATUS, newStatus, user);
+                                String newStatus = "Ready for - Assign from Investigator Decisions";
+                                if(match.getParentsOfType("Sample", user) != null && match.getParentsOfType
+                                        ("Sample", user).size() > 0) {
+                                    match.getParentsOfType("Sample", user).get(0).setDataField(DT_Sample.
+                                            EXEMPLAR_SAMPLE_STATUS, newStatus, user);
+
+                                    DataRecord sample = match.getParentsOfType("Sample", user).get(0);
+                                    String status = match.getParentsOfType("Sample", user).get(0).
+                                            getDataField(DT_Sample.EXEMPLAR_SAMPLE_STATUS, user).toString();
+
+                                    AssignedProcessConfig assignedProcessConfig = getProcessAssignerConfig(status, sample, user);
+                                    AssignedProcess assignedProcess = assignedProcessConfig.getProcessToAssign();
+                                    Map<String, Object> assignedProcessMap = AssignedProcessCreator.create(sample, assignedProcess, user);
+
+                                    List<DataRecord> assignedProcesses = dataRecordManager.addDataRecords(DT_AssignedProcess.DATA_TYPE,
+                                            Collections.singletonList(assignedProcessMap), user);
+                                    validateAssignedProcessAdded(assignedProcessMap, assignedProcesses);
+                                    //assignedProcesses.get(0);
+
+
+
+                                    // Add a record in "Assigned Process" table
+                                    String sampleId = match.getParentsOfType("Sample", user).
+                                            get(0).getDataField("SampleId", user).toString();
+                                    List<DataRecord> assigned = dataRecordManager.queryDataRecords("AssignedProcess",
+                                            "SampleId = '" + sampleId + "'", user);
+                                    log.info("assigned size: " + assigned.size());
+                                    if (assigned.size() != 1) {
+                                        return "Failed to set status for " + sampleId + " because it maps to multiple assigned Processes";
+                                    }
+                                    DataRecord[] childSamples = assigned.get(0).getChildrenOfType("Sample", user);
+                                    log.info("childSamples length: " + childSamples.length);
+                                    if (childSamples.length == 0) {
+                                        log.info("no sample under assigned process -> adding the sample as a child to assigned process");
+                                        assigned.get(0).addChild(match.getParentsOfType("Sample", user).get(0), user);
+                                    }
+                                }
                             }
                             count++;
                         }
@@ -83,4 +125,10 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
         return count + " Investigator Decisions set";
     }
 
+    private void validateAssignedProcessAdded(Map<String, Object> assignedProcessMap, List<DataRecord> assignedProcesses) {
+        if (assignedProcesses.size() == 0)
+            throw new RuntimeException(String.format("Unable to assign process to sample: %s (%s)",
+                    assignedProcessMap.get(DT_AssignedProcess.SAMPLE_ID), assignedProcessMap.get(DT_AssignedProcess
+                            .OTHER_SAMPLE_ID)));
+    }
 }

--- a/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
@@ -63,7 +63,7 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
                         if (String.valueOf(match.getRecordId()).equals(String.valueOf(field.get("RecordId")))) {
                             match.setDataField("InvestigatorDecision", field.get("InvestigatorDecision"), user);
                             if(field.get("InvestigatorDecision").toString().toLowerCase().contains("Continue processing")) {
-                                String newStatus = "Ready for - Decision made assign lab process";
+                                String newStatus = "Ready for - Pending User Decision";
                                 match.setDataField(DT_Sample.EXEMPLAR_SAMPLE_STATUS, newStatus, user);
                             }
 

--- a/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
@@ -10,8 +10,12 @@ import com.velox.api.datarecord.NotFound;
 import com.velox.api.sqlbuilder.*;
 import com.velox.api.util.ServerException;
 import com.velox.sapioutils.client.standalone.VeloxConnection;
+import com.velox.sloan.cmo.staticstrings.datatypes.DT_Sample;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.mskcc.limsrest.service.assignedprocess.AssignedProcess;
+import org.mskcc.limsrest.service.assignedprocess.AssignedProcessCreator;
+import org.mskcc.limsrest.service.assignedprocess.QcStatusAwareProcessAssigner;
 import org.mskcc.limsrest.util.Messages;
 import org.springframework.security.access.prepost.PreAuthorize;
 
@@ -28,6 +32,7 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
 
     private static Log log = LogFactory.getLog(SetQcInvestigatorDecisionTask.class);
     List<Map<String, Object>> data;
+    protected QcStatusAwareProcessAssigner qcStatusAwareProcessAssigner = new QcStatusAwareProcessAssigner();
 
     public SetQcInvestigatorDecisionTask() {
     }
@@ -57,6 +62,11 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
                     for (Map field : decisions) {
                         if (String.valueOf(match.getRecordId()).equals(String.valueOf(field.get("RecordId")))) {
                             match.setDataField("InvestigatorDecision", field.get("InvestigatorDecision"), user);
+                            if(field.get("InvestigatorDecision").toString().toLowerCase().contains("Continue processing")) {
+                                String newStatus = "Ready for - Decision made assign lab process";
+                                match.setDataField(DT_Sample.EXEMPLAR_SAMPLE_STATUS, newStatus, user);
+                            }
+
                             count++;
                         }
                     }

--- a/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
@@ -59,7 +59,7 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
                                         ("Sample", user).size() > 0) {
                                     match.getParentsOfType("Sample", user).get(0).setDataField(DT_Sample.
                                             EXEMPLAR_SAMPLE_STATUS, newStatus, user);
-                                    log.info("After assigning sample status to new status!");
+                                    log.info("After assigning sample status to " + newStatus + "!");
 
                                     DataRecord sample = match.getParentsOfType("Sample", user).get(0);
                                     String igoId = sample.getDataField("SampleId", user).toString();
@@ -86,6 +86,14 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
                                     log.info("qcStat igo id is:" + qcStat.getDataField("SampleId", user));
                                     qcStatusAwareProcessAssigner.assign(dataRecordManager, user, qcStat, QcStatus.fromString(newStatus));
                                     log.info("After assign is completed!");
+                                }
+                            } else if (field.get("InvestigatorDecision").toString().toLowerCase().contains("stop processing")) {
+                                String newStatus = "Awaiting Processing";
+                                if(match.getParentsOfType("Sample", user) != null && match.getParentsOfType
+                                        ("Sample", user).size() > 0) {
+                                    match.getParentsOfType("Sample", user).get(0).setDataField(DT_Sample.
+                                            EXEMPLAR_SAMPLE_STATUS, newStatus, user);
+                                    log.info("After assigning sample status to " + newStatus + "!");
                                 }
                             }
                             count++;

--- a/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
@@ -86,22 +86,6 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
                                     log.info("qcStat igo id is:" + qcStat.getDataField("SampleId", user));
                                     qcStatusAwareProcessAssigner.assign(dataRecordManager, user, qcStat, QcStatus.fromString(newStatus));
                                     log.info("After assign is completed!");
-
-//                                    String status = match.getParentsOfType("Sample", user).get(0).
-//                                            getDataField(DT_Sample.EXEMPLAR_SAMPLE_STATUS, user).toString();
-//
-//                                    // Add a record in "Assigned Process" table
-//                                    String sampleId = match.getParentsOfType("Sample", user).
-//                                            get(0).getDataField("SampleId", user).toString();
-//                                    List<DataRecord> assigned = dataRecordManager.queryDataRecords("AssignedProcess",
-//                                            "SampleId = '" + sampleId + "'", user);
-//                                    log.info("assigned size: " + assigned.size());
-//                                    DataRecord[] childSamples = assigned.get(0).getChildrenOfType("Sample", user);
-//                                    log.info("childSamples length: " + childSamples.length);
-//                                    if (childSamples.length == 0) {
-//                                        log.info("no sample under assigned process -> adding the sample as a child to assigned process");
-//                                        assigned.get(0).addChild(match.getParentsOfType("Sample", user).get(0), user);
-//                                    }
                                 }
                             }
                             count++;

--- a/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
@@ -62,11 +62,11 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
                     for (Map field : decisions) {
                         if (String.valueOf(match.getRecordId()).equals(String.valueOf(field.get("RecordId")))) {
                             match.setDataField("InvestigatorDecision", field.get("InvestigatorDecision"), user);
-                            if(field.get("InvestigatorDecision").toString().toLowerCase().contains("Continue processing")) {
+                            if(field.get("InvestigatorDecision").toString().toLowerCase().contains("continue processing")) {
                                 String newStatus = "Ready for - Pending User Decision";
-                                match.setDataField(DT_Sample.EXEMPLAR_SAMPLE_STATUS, newStatus, user);
+                                match.getParentsOfType("Sample", user).get(0).setDataField(DT_Sample.
+                                        EXEMPLAR_SAMPLE_STATUS, newStatus, user);
                             }
-
                             count++;
                         }
                     }

--- a/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/SetQcInvestigatorDecisionTask.java
@@ -33,14 +33,6 @@ public class SetQcInvestigatorDecisionTask extends LimsTask {
         this.data = data;
 
     }
-    public static AssignedProcessConfig getProcessAssignerConfig(String qcStatus, DataRecord sample, User user) throws Exception {
-        switch (qcStatus) {
-            case "Assign from Investigator Decisions":
-                return new ResequencePoolAssignedProcessConfig(sample, user);
-            default:
-                throw new RuntimeException(String.format("Not supported qc status: %s", qcStatus));
-        }
-    }
 
     @PreAuthorize("hasRole('READ')")
     @Override

--- a/src/main/java/org/mskcc/limsrest/service/assignedprocess/AssignedProcess.java
+++ b/src/main/java/org/mskcc/limsrest/service/assignedprocess/AssignedProcess.java
@@ -1,11 +1,12 @@
 package org.mskcc.limsrest.service.assignedprocess;
 
-import org.mskcc.domain.Workflow;
 
 public enum AssignedProcess {
     WHOLE_EXOME_CAPTURE("Whole Exome Capture", Workflow.CAPTURE_FROM_KAPA_LIBRARY),
     PRE_SEQUENCING_POOLING_OF_LIBRARIES("Pre-Sequencing Pooling of Libraries", Workflow.POOLING_OF_SAMPLE_LIBRARIES_FOR_SEQUENCING),
-    IMPACT_HEMEPACT_OR_CUSTOM_CAPTURE("IMPACT/HemePACT or Custom Capture", Workflow.CAPTURE_HYBRIDIZATION);
+    IMPACT_HEMEPACT_OR_CUSTOM_CAPTURE("IMPACT/HemePACT or Custom Capture", Workflow.CAPTURE_HYBRIDIZATION),
+    ASSIGN_FROM_INVESTIGATOR_DECISION("Assign from Investigator Decision", Workflow.ASSIGN_FROM_INVESTIGATOR_DECISION);
+
 
     private final String name;
     private final Workflow workflow;

--- a/src/main/java/org/mskcc/limsrest/service/assignedprocess/AssignedProcessCreator.java
+++ b/src/main/java/org/mskcc/limsrest/service/assignedprocess/AssignedProcessCreator.java
@@ -5,15 +5,18 @@ import com.velox.api.datarecord.NotFound;
 import com.velox.api.user.User;
 import com.velox.sloan.cmo.staticstrings.datatypes.DT_AssignedProcess;
 import com.velox.sloan.cmo.staticstrings.datatypes.DT_Sample;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.rmi.RemoteException;
 import java.util.HashMap;
 import java.util.Map;
 
 public class AssignedProcessCreator {
-    public static Map<String, Object> create(DataRecord sample, AssignedProcess assignedProcess, User user) throws Exception {
+    private final static Log log = LogFactory.getLog(AssignedProcessCreator.class);
+    public static Map<String, Object> create(DataRecord sample, AssignedProcess assignedProcess, boolean isSetInvestigatorDecision, User user) throws Exception {
         Map<String, Object> assignedProcessMap = new HashMap<>();
-
+        log.info("Inside create function!");
         String igoSampleId = sample.getStringVal(DT_Sample.SAMPLE_ID, user);
         String cmoSampleId = sample.getStringVal(DT_Sample.OTHER_SAMPLE_ID, user);
 
@@ -23,14 +26,22 @@ public class AssignedProcessCreator {
         assignedProcessMap.put(DT_AssignedProcess.OTHER_SAMPLE_ID, cmoSampleId);
         assignedProcessMap.put(DT_AssignedProcess.STATUS, assignedProcess.getStatus());
         assignedProcessMap.put(DT_AssignedProcess.SAMPLE_RECORD_ID, sample.getRecordId());
-        assignRequestRecordId(assignedProcessMap, sample, user);
-
+        assignRequestRecordId(assignedProcessMap, sample, isSetInvestigatorDecision, user);
+        log.info("Populated the map!");
         return assignedProcessMap;
     }
 
-    private static void assignRequestRecordId(Map<String, Object> assignedProcessMap, DataRecord sample, User user) throws
+    private static void assignRequestRecordId(Map<String, Object> assignedProcessMap, DataRecord sample, boolean isSetInvestigatorDecision, User user) throws
             NotFound, RemoteException {
-        String reqRecordIdsString = sample.getStringVal(DT_Sample.REQUEST_RECORD_ID_LIST, user);
+        log.info("In assignRequestRecordId");
+        String reqRecordIdsString;
+        if (isSetInvestigatorDecision) {
+            reqRecordIdsString = sample.getDataField(DT_Sample.RECORD_ID, user).toString();
+        }
+        else {
+            reqRecordIdsString = sample.getStringVal(DT_Sample.REQUEST_RECORD_ID_LIST, user);
+        }
+
         String[] reqRecordIds = reqRecordIdsString.split(",");
 
         if (reqRecordIds.length > 0)

--- a/src/main/java/org/mskcc/limsrest/service/assignedprocess/InvestigatorDecisionAssignedProcessConfig.java
+++ b/src/main/java/org/mskcc/limsrest/service/assignedprocess/InvestigatorDecisionAssignedProcessConfig.java
@@ -1,0 +1,21 @@
+package org.mskcc.limsrest.service.assignedprocess;
+
+import com.velox.api.datarecord.DataRecord;
+
+public class InvestigatorDecisionAssignedProcessConfig implements AssignedProcessConfig {
+    private DataRecord sample;
+
+    public InvestigatorDecisionAssignedProcessConfig(DataRecord sample) {
+        this.sample = sample;
+    }
+
+    @Override
+    public DataRecord getSample() {
+        return sample;
+    }
+
+    @Override
+    public AssignedProcess getProcessToAssign() {
+        return AssignedProcess.ASSIGN_FROM_INVESTIGATOR_DECISION;
+    }
+}

--- a/src/main/java/org/mskcc/limsrest/service/assignedprocess/QcStatus.java
+++ b/src/main/java/org/mskcc/limsrest/service/assignedprocess/QcStatus.java
@@ -1,5 +1,7 @@
 package org.mskcc.limsrest.service.assignedprocess;
 
+import org.mskcc.limsrest.controller.CheckOrMarkCmoRequests;
+
 public enum QcStatus {
     FAILED("Failed"),
     NEW_LIBRARY_NEEDED("New-Library-Needed"),
@@ -9,7 +11,9 @@ public enum QcStatus {
     REPOOL_SAMPLE("Repool-Sample"),
     REQUIRED_ADDITIONAL_READS("Required-Additional-Reads"),
     RESEQUENCE_POOL("Resequence-Pool"),
-    UNDER_REVIEW("Under-Review");
+    UNDER_REVIEW("Under-Review"),
+    //sample status when investigator decision is "Continue Processing"
+    CONTINUE_PROCESSING("Ready for - Assign from Investigator Decisions");
 
     private String text;
 

--- a/src/main/java/org/mskcc/limsrest/service/assignedprocess/Workflow.java
+++ b/src/main/java/org/mskcc/limsrest/service/assignedprocess/Workflow.java
@@ -1,0 +1,25 @@
+package org.mskcc.limsrest.service.assignedprocess;
+
+public enum Workflow {
+    POOLING_OF_SAMPLE_LIBRARIES_FOR_SEQUENCING("Pooling of Sample Libraries for Sequencing", 1),
+    CAPTURE_FROM_KAPA_LIBRARY("Capture from KAPA Library", 1),
+    LIBRARY_POOL_QUALITY_CONTROL("Library/Pool Quality Control", 1),
+    CAPTURE_HYBRIDIZATION("Capture - Hybridization", 1),
+    ASSIGN_FROM_INVESTIGATOR_DECISION("Assign from Investigator Decisions", 1);
+
+    private final String name;
+    private final int stepNumber;
+
+    private Workflow(String name, int stepNumber) {
+        this.name = name;
+        this.stepNumber = stepNumber;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getStepNumber() {
+        return this.stepNumber;
+    }
+}

--- a/src/test/java/org/mskcc/limsrest/service/assignedprocess/AssignedProcessCreatorTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/assignedprocess/AssignedProcessCreatorTest.java
@@ -33,7 +33,7 @@ public class AssignedProcessCreatorTest {
         when(sample.getStringVal(DT_Sample.REQUEST_RECORD_ID_LIST, userMock)).thenReturn("12345_A,23456_B,34567_C");
 
         //when
-        Map<String, Object> assignedProcessMap = AssignedProcessCreator.create(sample, assignedProcess, userMock);
+        Map<String, Object> assignedProcessMap = AssignedProcessCreator.create(sample, assignedProcess, false, userMock);
 
         //then
         assertThat(assignedProcessMap.containsKey(DT_AssignedProcess.SAMPLE_ID), is(true));

--- a/src/test/java/org/mskcc/limsrest/service/assignedprocess/QcStatusAwareProcessAssignerTest.java
+++ b/src/test/java/org/mskcc/limsrest/service/assignedprocess/QcStatusAwareProcessAssignerTest.java
@@ -32,6 +32,6 @@ public class QcStatusAwareProcessAssignerTest {
                 .thenReturn(Arrays.asList
                         (mock(DataRecord.class)));
 
-        when(AssignedProcessCreator.create(any(), any(), any())).thenReturn(assProcMap);
+        when(AssignedProcessCreator.create(any(), any(), false, any())).thenReturn(assProcMap);
     }
 }


### PR DESCRIPTION
When a decision is made by investigators for samples after initial QC, if the decision is "Continue Processing" we would like to send samples to a new queue in LIMS which is technically similar to assign samples to process (An indirect launch workflow).