### PR TITLE
Updating the returned object

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetTenXSampleInfoTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetTenXSampleInfoTask.java
@@ -58,22 +58,13 @@ public class GetTenXSampleInfoTask {
                     log.info("recipe of sample " + sample.getStringVal("SampleId", user) + " is: " + recipe);
                     samplesInfo.add(ilabRequest);
                     samplesInfo.add(sampleName);
-                    if (recipe.toLowerCase().contains("featurebarcoding")) { // Feature Barcoding
-                        String treatment = request.getStringVal("Treatment", user);
-                        log.info("treatment = " + treatment);
-                        recipe += ", " + treatment;
-                        samplesInfo.add(recipe);
-                        samplesToRecipes.put(sample.getStringVal("SampleId", user), samplesInfo);
-                    } else if (recipe.toLowerCase().contains("vdj")) { // VDJ
-                        String cellTypes = request.getStringVal("CellTypes", user);
-                        log.info("cellTypes = " + cellTypes);
-                        recipe += ", " + cellTypes;
-                        samplesInfo.add(recipe);
-                        samplesToRecipes.put(sample.getStringVal("SampleId", user), samplesInfo);
-                    } else { // Gene Expression
-                        samplesInfo.add(recipe);
-                        samplesToRecipes.put(sample.getStringVal("SampleId", user), samplesInfo);
-                    }
+                    String treatment = request.getStringVal("Treatment", user);
+                    log.info("treatment = " + treatment);
+                    String cellTypes = request.getStringVal("CellTypes", user);
+                    log.info("cellTypes = " + cellTypes);
+                    recipe += ", " + treatment + ", " + cellTypes;
+                    samplesInfo.add(recipe);
+                    samplesToRecipes.put(sample.getStringVal("SampleId", user), samplesInfo);
                 }
                 samplesRecipes.add(samplesToRecipes);
             }


### PR DESCRIPTION
This change is due to, all 10X requests in LIMS which are related to one project have one iLab form and we need to append iLab information to all projects irrespective of the recipe.