### PR TITLE
Enabling Hide from sample QC field in SDMS.

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/GetQcReportSamplesTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/GetQcReportSamplesTask.java
@@ -225,7 +225,7 @@ public class GetQcReportSamplesTask {
                         HashMap<String, Object> attachmentInfo = new HashMap<>();
                         attachmentInfo.put("recordId", record.getDataField("RecordId", user));
                         attachmentInfo.put("fileName", record.getDataField("FilePath", user));
-                        //attachmentInfo.put("hideFromSampleQC", record.getDataField("HideFromSampleQC", user));
+                        attachmentInfo.put("hideFromSampleQC", record.getDataField("HideFromSampleQC", user));
                         attachments.add(attachmentInfo);
                     }
                 }


### PR DESCRIPTION
SDMS field is added to SDMS on prod and dev LIMS.
Addressing: https://mskcc.teamwork.com/app/tasks/28443294