### PR TITLE
Disable Airflow trigger for failed samples

### DIFF
--- a/src/main/java/org/mskcc/limsrest/service/ToggleSampleQcStatusTask.java
+++ b/src/main/java/org/mskcc/limsrest/service/ToggleSampleQcStatusTask.java
@@ -126,22 +126,22 @@ public class ToggleSampleQcStatusTask {
                     log.info("SeqAnalysisSampleQC updated to:" + status + " from:" + currentStatusLIMS);
 
                     // Call Airflow to move the fastq.gz files if failed
-                    if (qcStatus == QcStatus.FAILED) {
-                        if (airflow_pass == null || airflow_pass == "")
-                            log.error("Airflow password not initialized, can't move failed fastq.gz files.");
-                        else {
-                            String igoIdFromLims = (String) seqQc.getDataField("SampleId", user); // IGO ID
-                            String runFromLims = (String) seqQc.getDataField("SequencerRunFolder", user);
-
-                            Date execDate = new Date(System.currentTimeMillis() + 10000);
-                            String body = formatMoveFailedFastqJSON(igoIdFromLims, runFromLims, execDate);
-                            String cmd = "/bin/curl -X POST -d '" + body + "' \"http://igo-ln01:8080/api/v1/dags/move_failed_fastqs/dagRuns\" -H 'content-type: application/json' --user \"airflow-api:" + airflow_pass + "\"";
-                            log.info("Calling airflow pipeline to move failed fastq.gz files: " + cmd);
-                            ProcessBuilder processBuilder = new ProcessBuilder();
-                            processBuilder.command("bash", "-c", cmd);
-                            Process process = processBuilder.start();
-                        }
-                    }
+//                    if (qcStatus == QcStatus.FAILED) {
+//                        if (airflow_pass == null || airflow_pass == "")
+//                            log.error("Airflow password not initialized, can't move failed fastq.gz files.");
+//                        else {
+//                            String igoIdFromLims = (String) seqQc.getDataField("SampleId", user); // IGO ID
+//                            String runFromLims = (String) seqQc.getDataField("SequencerRunFolder", user);
+//
+//                            Date execDate = new Date(System.currentTimeMillis() + 10000);
+//                            String body = formatMoveFailedFastqJSON(igoIdFromLims, runFromLims, execDate);
+//                            String cmd = "/bin/curl -X POST -d '" + body + "' \"http://igo-ln01:8080/api/v1/dags/move_failed_fastqs/dagRuns\" -H 'content-type: application/json' --user \"airflow-api:" + airflow_pass + "\"";
+//                            log.info("Calling airflow pipeline to move failed fastq.gz files: " + cmd);
+//                            ProcessBuilder processBuilder = new ProcessBuilder();
+//                            processBuilder.command("bash", "-c", cmd);
+//                            Process process = processBuilder.start();
+//                        }
+//                    }
                 }
                 else if (isOnt) {
                     log.info("SequencingAnalysisONT updating to " + status + " for record:" + recordId);


### PR DESCRIPTION
The Airflow trigger for moving FASTQs is no longer needed as failed samples' are being handled in the [Delivery code](https://github.com/mskcc/igo-delivery/blob/main/LinkProjectToSamples.py).